### PR TITLE
Add 'fake' usrname & pword to url passed to git clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The base path of mounts inside the sandbox is now `/opt/rustwide` on Linux
   and `C:\rustwide` on Windows.
 
+### Fixed
+
+- Issue with cloning repos on Windows caused by the credential manager.
+
 ## [0.1.0] - 2019-08-22
 
 ### Added

--- a/src/crates/git.rs
+++ b/src/crates/git.rs
@@ -70,7 +70,13 @@ impl CrateTrait for GitRepo {
         } else {
             info!("cloning repository {}", self.url);
             Command::new(workspace, "git")
-                .args(&["clone", "--bare", &self.url])
+                .args(&[
+                    "clone",
+                    "--bare",
+                    // avoid issues with git credentials helper on Windows by
+                    // providing fake credentials that GitHub will ignore.
+                    &self.url.replace("https://", "https://ghost:ghost@"),
+                ])
                 .args(&[&path])
                 .run()
                 .with_context(|_| format!("failed to clone {}", self.url))?;


### PR DESCRIPTION
The git credentials manager on Windows is a bit finicky and sometimes requires
providing credentials even when this is not strictly necessary. By
providing _some_ credentials in the url, we can force the credentials
manager to simply pass them along to GitHub which will ignore them due to
the repos being public.