### PR TITLE
Use resilient `remove_dir_all` for Windows compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Issue with cloning repos on Windows caused by the credential manager.
+- Fix failing cleanups on Windows by using the `remove_dir_all` crate.
 
 ## [0.1.0] - 2019-08-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ percent-encoding = "2.1.0"
 walkdir = "2.2"
 toml = "0.4.6"
 fs2 = "0.4.3"
+remove_dir_all = "0.5.2"
 
 [dev-dependencies]
 env_logger = "0.6.1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -2,6 +2,7 @@ use crate::cmd::{Command, MountKind, Runnable, SandboxBuilder};
 use crate::prepare::Prepare;
 use crate::{Crate, Toolchain, Workspace};
 use failure::Error;
+use remove_dir_all::remove_dir_all;
 use std::path::PathBuf;
 
 /// Directory in the [`Workspace`](struct.Workspace.html) where builds can be executed.
@@ -56,7 +57,7 @@ impl BuildDirectory {
     ) -> Result<R, Error> {
         let source_dir = self.source_dir();
         if source_dir.exists() {
-            std::fs::remove_dir_all(&source_dir)?;
+            remove_dir_all(&source_dir)?;
         }
 
         let mut prepare = Prepare::new(&self.workspace, toolchain, krate, &source_dir);
@@ -69,7 +70,7 @@ impl BuildDirectory {
             sandbox: sandbox.clone(),
         })?;
 
-        std::fs::remove_dir_all(&source_dir)?;
+        remove_dir_all(&source_dir)?;
         Ok(res)
     }
 
@@ -77,7 +78,7 @@ impl BuildDirectory {
     pub fn purge(&mut self) -> Result<(), Error> {
         let build_dir = self.build_dir();
         if build_dir.exists() {
-            std::fs::remove_dir_all(build_dir)?;
+            remove_dir_all(build_dir)?;
         }
         Ok(())
     }

--- a/src/crates/cratesio.rs
+++ b/src/crates/cratesio.rs
@@ -3,6 +3,7 @@ use crate::Workspace;
 use failure::Error;
 use flate2::read::GzDecoder;
 use log::info;
+use remove_dir_all::remove_dir_all;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read};
 use std::path::{Path, PathBuf};
@@ -70,7 +71,7 @@ impl CrateTrait for CratesIOCrate {
             dest.display()
         );
         if let Err(err) = unpack_without_first_dir(&mut tar, dest) {
-            let _ = std::fs::remove_dir_all(dest);
+            let _ = remove_dir_all(dest);
             Err(err
                 .context(format!(
                     "unable to download {} version {}",

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -5,6 +5,7 @@ mod local;
 use crate::Workspace;
 use failure::Error;
 use log::info;
+use remove_dir_all::remove_dir_all;
 use std::path::Path;
 
 trait CrateTrait: std::fmt::Display {
@@ -62,7 +63,7 @@ impl Crate {
                 "crate source directory {} already exists, cleaning it up",
                 dest.display()
             );
-            std::fs::remove_dir_all(dest)?;
+            remove_dir_all(dest)?;
         }
         self.as_trait().copy_source_to(workspace, dest)
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3,6 +3,7 @@ use crate::cmd::{Command, SandboxImage};
 use crate::Toolchain;
 use failure::{Error, ResultExt};
 use log::info;
+use remove_dir_all::remove_dir_all;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -150,7 +151,7 @@ impl Workspace {
 
     /// Remove all the contents of all the build directories, freeing disk space.
     pub fn purge_all_build_dirs(&self) -> Result<(), Error> {
-        std::fs::remove_dir_all(self.builds_dir())?;
+        remove_dir_all(self.builds_dir())?;
         Ok(())
     }
 


### PR DESCRIPTION
`std::fs::remove_dir_all` can fail spuriously on Windows.