### PR TITLE
API to allow applying patches to crates

### DIFF
--- a/examples/docs-builder.rs
+++ b/examples/docs-builder.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .enable_networking(false);
 
     let mut build_dir = workspace.build_dir("docs");
-    build_dir.build(&toolchain, &krate, sandbox, |build| {
+    build_dir.build(&toolchain, &krate, sandbox).run(|build| {
         build.cargo().args(&["doc", "--no-deps"]).run()?;
         Ok(())
     })?;

--- a/src/build.rs
+++ b/src/build.rs
@@ -10,7 +10,7 @@ use std::vec::Vec;
 pub struct CratePatch {
     pub name: String,
     pub uri: String,
-    pub branch: String
+    pub branch: String,
 }
 
 /// Directory in the [`Workspace`](struct.Workspace.html) where builds can be executed.
@@ -33,7 +33,6 @@ pub struct Builder<'a> {
 }
 
 impl<'a> Builder<'a> {
-
     /// Add a patch to this build.
     /// Patches get added to the crate's Cargo.toml in the `patch.crates-io` table.
     /// # Example
@@ -56,7 +55,7 @@ impl<'a> Builder<'a> {
     /// # Ok(())
     /// # }
     pub fn patch_with_git(mut self, name: String, uri: String, branch: String) -> Self {
-        self.patches.push(CratePatch { name, uri, branch});
+        self.patches.push(CratePatch { name, uri, branch });
         self
     }
 
@@ -84,7 +83,8 @@ impl<'a> Builder<'a> {
     /// # Ok(())
     /// # }
     pub fn run<R, F: FnOnce(&Build) -> Result<R, Error>>(self, f: F) -> Result<R, Error> {
-        self.build_dir.run(self.toolchain, self.krate, self.sandbox, self.patches, f)
+        self.build_dir
+            .run(self.toolchain, self.krate, self.sandbox, self.patches, f)
     }
 }
 
@@ -117,13 +117,18 @@ impl BuildDirectory {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn build<'a>(&'a mut self,
+    pub fn build<'a>(
+        &'a mut self,
         toolchain: &'a Toolchain,
         krate: &'a Crate,
         sandbox: SandboxBuilder,
     ) -> Builder {
         Builder {
-            build_dir: self, toolchain, krate, sandbox, patches: Vec::new()
+            build_dir: self,
+            toolchain,
+            krate,
+            sandbox,
+            patches: Vec::new(),
         }
     }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -6,14 +6,10 @@ use remove_dir_all::remove_dir_all;
 use std::path::PathBuf;
 use std::vec::Vec;
 
-/// Holds info for a patch to be added to a crate's Cargo.toml
 #[derive(Clone)]
 pub struct CratePatch {
-    /// Crate name to patch
     pub name: String,
-    /// URL of the git repo
     pub uri: String,
-    /// Branch of the git repo
     pub branch: String
 }
 
@@ -43,25 +39,24 @@ impl<'a> Builder<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use rustwide::{WorkspaceBuilder, Toolchain, Crate, CratePatch, cmd::SandboxBuilder};
+    /// # use rustwide::{WorkspaceBuilder, Toolchain, Crate, cmd::SandboxBuilder};
     /// # use std::error::Error;
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// # let workspace = WorkspaceBuilder::new("".as_ref(), "").init()?;
     /// # let toolchain = Toolchain::Dist { name: "".into() };
     /// # let krate = Crate::local("".as_ref());
     /// # let sandbox = SandboxBuilder::new();
-    /// let crate_patch = CratePatch { name: "bar".into(), uri: "https://github.com/foo/bar".into(), branch: "baz".into() };
     /// let mut build_dir = workspace.build_dir("foo");
     /// build_dir.build(&toolchain, &krate, sandbox)
-    ///     .patch(crate_patch)
+    ///     .patch_with_git("bar".into(), "https://github.com/foo/bar".into(), "baz".into())
     ///     .run(|build| {
     ///         build.cargo().args(&["test", "--all"]).run()?;
     ///         Ok(())
     /// })?;
     /// # Ok(())
     /// # }
-    pub fn patch(mut self, patch: CratePatch) -> Self {
-        self.patches.push(patch);
+    pub fn patch_with_git(mut self, name: String, uri: String, branch: String) -> Self {
+        self.patches.push(CratePatch { name, uri, branch});
         self
     }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -47,15 +47,19 @@ impl<'a> BuildBuilder<'a> {
     /// # let sandbox = SandboxBuilder::new();
     /// let mut build_dir = workspace.build_dir("foo");
     /// build_dir.build(&toolchain, &krate, sandbox)
-    ///     .patch_with_git("bar".into(), "https://github.com/foo/bar".into(), "baz".into())
+    ///     .patch_with_git("bar", "https://github.com/foo/bar", "baz")
     ///     .run(|build| {
     ///         build.cargo().args(&["test", "--all"]).run()?;
     ///         Ok(())
-    /// })?;
+    ///     })?;
     /// # Ok(())
     /// # }
     pub fn patch_with_git(mut self, name: &str, uri: &str, branch: &str) -> Self {
-        self.patches.push(CratePatch { name: name.into(), uri: uri.into(), branch: branch.into() });
+        self.patches.push(CratePatch {
+            name: name.into(),
+            uri: uri.into(),
+            branch: branch.into(),
+        });
         self
     }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 use std::vec::Vec;
 
 #[derive(Clone)]
-pub struct CratePatch {
-    pub name: String,
-    pub uri: String,
-    pub branch: String,
+pub(crate) struct CratePatch {
+    pub(crate) name: String,
+    pub(crate) uri: String,
+    pub(crate) branch: String,
 }
 
 /// Directory in the [`Workspace`](struct.Workspace.html) where builds can be executed.

--- a/src/build.rs
+++ b/src/build.rs
@@ -24,7 +24,7 @@ pub struct BuildDirectory {
 }
 
 /// Builder for configuring builds in a [`BuildDirectory`](struct.BuildDirectory.html).
-pub struct Builder<'a> {
+pub struct BuildBuilder<'a> {
     build_dir: &'a mut BuildDirectory,
     toolchain: &'a Toolchain,
     krate: &'a Crate,
@@ -32,7 +32,7 @@ pub struct Builder<'a> {
     patches: Vec<CratePatch>,
 }
 
-impl<'a> Builder<'a> {
+impl<'a> BuildBuilder<'a> {
     /// Add a patch to this build.
     /// Patches get added to the crate's Cargo.toml in the `patch.crates-io` table.
     /// # Example
@@ -54,8 +54,8 @@ impl<'a> Builder<'a> {
     /// })?;
     /// # Ok(())
     /// # }
-    pub fn patch_with_git(mut self, name: String, uri: String, branch: String) -> Self {
-        self.patches.push(CratePatch { name, uri, branch });
+    pub fn patch_with_git(mut self, name: &str, uri: &str, branch: &str) -> Self {
+        self.patches.push(CratePatch { name: name.into(), uri: uri.into(), branch: branch.into() });
         self
     }
 
@@ -122,8 +122,8 @@ impl BuildDirectory {
         toolchain: &'a Toolchain,
         krate: &'a Crate,
         sandbox: SandboxBuilder,
-    ) -> Builder {
-        Builder {
+    ) -> BuildBuilder {
+        BuildBuilder {
             build_dir: self,
             toolchain,
             krate,

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -28,25 +28,25 @@ pub struct CratePatch {
 }
 
 /// A Rust crate that can be used with rustwide.
-pub struct Crate(CrateType, Option<Vec<CratePatch>>);
+pub struct Crate(CrateType);
 
 impl Crate {
     /// Load a crate from the [crates.io registry](https://crates.io).
     pub fn crates_io(name: &str, version: &str) -> Self {
         Crate(CrateType::CratesIO(cratesio::CratesIOCrate::new(
             name, version,
-        )), None)
+        )))
     }
 
     /// Load a crate from a git repository. The full URL needed to clone the repo has to be
     /// provided.
     pub fn git(url: &str) -> Self {
-        Crate(CrateType::Git(git::GitRepo::new(url)), None)
+        Crate(CrateType::Git(git::GitRepo::new(url)))
     }
 
     /// Load a crate from a directory in the local filesystem.
     pub fn local(path: &Path) -> Self {
-        Crate(CrateType::Local(local::Local::new(path)), None)
+        Crate(CrateType::Local(local::Local::new(path)))
     }
 
     /// Fetch the crate's source code and cache it in the workspace. This method will reach out to
@@ -68,15 +68,6 @@ impl Crate {
         } else {
             None
         }
-    }
-
-    pub(crate) fn add_patch(&mut self, patch: CratePatch) {
-        let patches: &mut Vec<CratePatch> = self.1.get_or_insert(Vec::new());
-        patches.push(patch);
-    }
-
-    pub(crate) fn patches(&self) -> &Option<Vec<CratePatch>> {
-        &self.1
     }
 
     pub(crate) fn copy_source_to(&self, workspace: &Workspace, dest: &Path) -> Result<(), Error> {

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -20,13 +20,6 @@ enum CrateType {
     Local(local::Local),
 }
 
-#[derive(Clone)]
-pub struct CratePatch {
-    pub name: String,
-    pub uri: String,
-    pub branch: String
-}
-
 /// A Rust crate that can be used with rustwide.
 pub struct Crate(CrateType);
 

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -20,26 +20,32 @@ enum CrateType {
     Local(local::Local),
 }
 
+pub struct CratePatch {
+    name: String,
+    uri: String,
+    branch: String
+}
+
 /// A Rust crate that can be used with rustwide.
-pub struct Crate(CrateType);
+pub struct Crate(CrateType, Option<Vec<CratePatch>>);
 
 impl Crate {
     /// Load a crate from the [crates.io registry](https://crates.io).
     pub fn crates_io(name: &str, version: &str) -> Self {
         Crate(CrateType::CratesIO(cratesio::CratesIOCrate::new(
             name, version,
-        )))
+        )), None)
     }
 
     /// Load a crate from a git repository. The full URL needed to clone the repo has to be
     /// provided.
     pub fn git(url: &str) -> Self {
-        Crate(CrateType::Git(git::GitRepo::new(url)))
+        Crate(CrateType::Git(git::GitRepo::new(url)), None)
     }
 
     /// Load a crate from a directory in the local filesystem.
     pub fn local(path: &Path) -> Self {
-        Crate(CrateType::Local(local::Local::new(path)))
+        Crate(CrateType::Local(local::Local::new(path)), None)
     }
 
     /// Fetch the crate's source code and cache it in the workspace. This method will reach out to
@@ -61,6 +67,11 @@ impl Crate {
         } else {
             None
         }
+    }
+
+    pub(crate) fn add_patch(&mut self, patch: CratePatch) {
+        let patches: &mut Vec<CratePatch> = self.1.get_or_insert(Vec::new());
+        patches.push(patch);
     }
 
     pub(crate) fn copy_source_to(&self, workspace: &Workspace, dest: &Path) -> Result<(), Error> {

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -20,10 +20,11 @@ enum CrateType {
     Local(local::Local),
 }
 
+#[derive(Clone)]
 pub struct CratePatch {
-    name: String,
-    uri: String,
-    branch: String
+    pub name: String,
+    pub uri: String,
+    pub branch: String
 }
 
 /// A Rust crate that can be used with rustwide.
@@ -72,6 +73,10 @@ impl Crate {
     pub(crate) fn add_patch(&mut self, patch: CratePatch) {
         let patches: &mut Vec<CratePatch> = self.1.get_or_insert(Vec::new());
         patches.push(patch);
+    }
+
+    pub(crate) fn patches(&self) -> &Option<Vec<CratePatch>> {
+        &self.1
     }
 
     pub(crate) fn copy_source_to(&self, workspace: &Workspace, dest: &Path) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod tools;
 mod utils;
 mod workspace;
 
-pub use crate::build::{Build, BuildDirectory};
+pub use crate::build::{Build, BuildDirectory, BuildBuilder};
 pub use crate::crates::Crate;
 pub use crate::prepare::PrepareError;
 pub use crate::toolchain::Toolchain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod tools;
 mod utils;
 mod workspace;
 
-pub use crate::build::{Build, BuildDirectory, BuildBuilder};
+pub use crate::build::{Build, BuildBuilder, BuildDirectory};
 pub use crate::crates::Crate;
 pub use crate::prepare::PrepareError;
 pub use crate::toolchain::Toolchain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod tools;
 mod utils;
 mod workspace;
 
-pub use crate::build::{Build, BuildDirectory, CratePatch};
+pub use crate::build::{Build, BuildDirectory};
 pub use crate::crates::Crate;
 pub use crate::prepare::PrepareError;
 pub use crate::toolchain::Toolchain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod tools;
 mod utils;
 mod workspace;
 
-pub use crate::build::{Build, BuildDirectory};
+pub use crate::build::{Build, BuildDirectory, CratePatch};
 pub use crate::crates::Crate;
 pub use crate::prepare::PrepareError;
 pub use crate::toolchain::Toolchain;

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -142,7 +142,7 @@ impl<'a> Prepare<'a> {
     }
 }
 
-pub struct TomlTweaker<'a> {
+struct TomlTweaker<'a> {
     krate: &'a Crate,
     table: Table,
     dir: Option<&'a Path>,

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -1,5 +1,5 @@
 use crate::cmd::Command;
-use crate::{Crate, Toolchain, CratePatch, Workspace};
+use crate::{Crate, Toolchain, Workspace, build::CratePatch};
 use failure::{Error, Fail, ResultExt};
 use log::info;
 use std::path::Path;
@@ -365,7 +365,8 @@ pub enum PrepareError {
 #[cfg(test)]
 mod tests {
     use super::TomlTweaker;
-    use crate::{CratePatch, crates::Crate};
+    use crate::crates::Crate;
+    use crate::build::CratePatch;
     use toml::{self, Value};
 
     #[test]

--- a/tests/buildtest/runner.rs
+++ b/tests/buildtest/runner.rs
@@ -43,7 +43,7 @@ impl Runner {
     ) -> Result<T, Error> {
         let mut dir = self.workspace.build_dir(&self.crate_name);
         dir.purge()?;
-        dir.build(self.toolchain, &self.krate, sandbox, f)
+        dir.build(self.toolchain, &self.krate, sandbox).run(f)
     }
 }
 

--- a/tests/integration/crates_git.rs
+++ b/tests/integration/crates_git.rs
@@ -18,16 +18,16 @@ fn test_fetch() -> Result<(), Error> {
     let cloned_commit = || -> Result<String, Error> {
         let mut dir = workspace.build_dir("integration-crates_git-test_fetch");
         dir.purge()?;
-        Ok(
-            dir.build(&toolchain, &krate, SandboxBuilder::new()).run(|build| {
+        Ok(dir
+            .build(&toolchain, &krate, SandboxBuilder::new())
+            .run(|build| {
                 Ok(Command::new(&workspace, "git")
                     .args(&["rev-parse", "HEAD"])
                     .cd(build.host_source_dir())
                     .run_capture()?
                     .stdout_lines()[0]
                     .to_string())
-            })?,
-        )
+            })?)
     };
 
     // Check if the initial commit was fetched

--- a/tests/integration/crates_git.rs
+++ b/tests/integration/crates_git.rs
@@ -19,7 +19,7 @@ fn test_fetch() -> Result<(), Error> {
         let mut dir = workspace.build_dir("integration-crates_git-test_fetch");
         dir.purge()?;
         Ok(
-            dir.build(&toolchain, &krate, SandboxBuilder::new(), |build| {
+            dir.build(&toolchain, &krate, SandboxBuilder::new()).run(|build| {
                 Ok(Command::new(&workspace, "git")
                     .args(&["rev-parse", "HEAD"])
                     .cd(build.host_source_dir())


### PR DESCRIPTION
This PR is part of rust-lang/crater#441 and adds a public api to allow adding patch tables to crates.

It adds a builder in front of the `BuildDirectory::build` method and adds any patches to the crate's Cargo.toml during tweaking.

Thanks!