### PR TITLE
Give a better error message for broken symbolic links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The directory `target/` inside local crates won't be copied into the build
   anymore.
+- Symbolic links will be followed instead of copied as links.
+  Better error messages will be given for broken symbolic links.
 
 ## [0.3.2] - 2019-10-08
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustwide/issues/13.

This returns an instance of `walkdir::Error` instead of `std::io::Error` so that it contains the filename,
not just the error code.