### PR TITLE
Read string out of target name instead of serializing toml value to a string

### DIFF
--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -198,9 +198,12 @@ impl<'a> TomlTweaker<'a> {
         value
             .iter()
             .filter_map(|t| t.as_table())
-            .filter(|t| t.get("name").is_some())
-            .map(|table| {
-                let name = table.get("name").unwrap().to_string();
+            .filter_map(|t| {
+                t.get("name")
+                    .and_then(Value::as_str)
+                    .map(|n| (t, n.to_owned()))
+            })
+            .map(|(table, name)| {
                 let path = table.get("path").map_or_else(
                     || dir.join(folder).join(name + ".rs"),
                     |path| dir.join(path.as_str().unwrap()),


### PR DESCRIPTION
Should fix https://github.com/rust-lang/crater/issues/493, but I haven't setup enough of a crater dev environment to test it yet.

(I did test this function in isolation run against that crate to make sure it no longer removed the tests).