### PR TITLE
use cargo install to update binaries

### DIFF
--- a/src/tools/binary_crates.rs
+++ b/src/tools/binary_crates.rs
@@ -58,25 +58,7 @@ impl Tool for BinaryCrate {
         Ok(())
     }
 
-    #[cfg(not(feature = "unstable"))]
-    fn update(&self, workspace: &Workspace, _fast_install: bool) -> Result<(), Error> {
-        Command::new(workspace, &crate::tools::CARGO_INSTALL_UPDATE)
-            .args(&[self.crate_name])
-            .timeout(None)
-            .run()?;
-        Ok(())
-    }
-
-    #[cfg(feature = "unstable")]
     fn update(&self, workspace: &Workspace, fast_install: bool) -> Result<(), Error> {
-        let mut cmd = Command::new(workspace, &Toolchain::MAIN.cargo())
-            .args(&["-Zinstall-upgrade", "install", self.crate_name])
-            .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
-            .timeout(None);
-        if fast_install {
-            cmd = cmd.args(&["--debug"]);
-        }
-        cmd.run()?;
-        Ok(())
+        self.install(workspace, fast_install)
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,13 +11,6 @@ use std::path::PathBuf;
 
 pub(crate) static RUSTUP: Rustup = Rustup;
 
-#[cfg(not(feature = "unstable"))]
-pub(crate) static CARGO_INSTALL_UPDATE: BinaryCrate = BinaryCrate {
-    crate_name: "cargo-update",
-    binary: "cargo-install-update",
-    cargo_subcommand: Some("install-update"),
-};
-
 pub(crate) static RUSTUP_TOOLCHAIN_INSTALL_MASTER: BinaryCrate = BinaryCrate {
     crate_name: "rustup-toolchain-install-master",
     binary: "rustup-toolchain-install-master",
@@ -32,8 +25,6 @@ pub(crate) static GIT_CREDENTIAL_NULL: BinaryCrate = BinaryCrate {
 
 static INSTALLABLE_TOOLS: &[&dyn Tool] = &[
     &RUSTUP,
-    #[cfg(not(feature = "unstable"))]
-    &CARGO_INSTALL_UPDATE,
     &RUSTUP_TOOLCHAIN_INSTALL_MASTER,
     &GIT_CREDENTIAL_NULL,
 ];


### PR DESCRIPTION
Use `cargo install` from rust stable to update binaries instead of using `cargo_update` or nightly flags.