### PR TITLE
Fix process lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix `Command::process_lines` not working in sandboxed enviroments. 
+
 ## [0.6.0] - 2020-04-01
 
 ### Added

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -345,7 +345,12 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 .env("CARGO_HOME", container_dirs::CARGO_HOME.to_str().unwrap())
                 .env("RUSTUP_HOME", container_dirs::RUSTUP_HOME.to_str().unwrap());
 
-            builder.run(workspace, self.timeout, self.no_output_timeout)?;
+            builder.run(
+                workspace,
+                self.timeout,
+                self.no_output_timeout,
+                self.process_lines,
+            )?;
             Ok(ProcessOutput {
                 stdout: Vec::new(),
                 stderr: Vec::new(),

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -24,6 +24,32 @@ fn test_hello_world() {
 }
 
 #[test]
+fn test_process_lines() {
+    runner::run("hello-world", |run| {
+        run.build(SandboxBuilder::new().enable_networking(false), |build| {
+            let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
+            let mut ex = false;
+            rustwide::logging::capture(&storage, || -> Result<_, Error> {
+                build
+                    .cargo()
+                    .process_lines(&mut |line: &str| {
+                        if line.contains("Hello, world!") {
+                            ex = true;
+                        }
+                    })
+                    .args(&["run"])
+                    .run()?;
+                Ok(())
+            })?;
+
+            assert!(ex);
+            Ok(())
+        })?;
+        Ok(())
+    });
+}
+
+#[test]
 #[cfg(not(windows))]
 fn test_sandbox_oom() {
     use rustwide::cmd::CommandError;


### PR DESCRIPTION
Fix `process_lines` not working in sandboxed enviroments