### PR TITLE
respect command configs in sanboxed env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Subcommands executed in sandbox respect configs of parent command
 - Added logging of exact image hash used during build
 
 ## [0.7.1] - 2020-05-20

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -364,11 +364,10 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 self.timeout,
                 self.no_output_timeout,
                 self.process_lines,
-            )?;
-            Ok(ProcessOutput {
-                stdout: Vec::new(),
-                stderr: Vec::new(),
-            })
+                self.log_output,
+                self.log_command,
+                capture,
+            )
         } else {
             let (binary, managed_by_rustwide) = match self.binary {
                 Binary::Global(path) => (path, false),


### PR DESCRIPTION
Sub-commands executed in sandbox now use the same config of the parent command. 
In particular, these options were added: 
* `log_command`
* `log_output`
* `capture`
