### PR TITLE
Add the Workspace::purge_all_caches method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New method `Workspace::purge_all_caches`
+
 ### Changed
 
 - Subcommands executed in sandbox respect configs of parent command

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,3 @@ getrandom = { version = "0.1.12", features = ["std"] }
 [dev-dependencies]
 env_logger = "0.6.1"
 tiny_http = "0.7.0"
-sha1 = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ getrandom = { version = "0.1.12", features = ["std"] }
 [dev-dependencies]
 env_logger = "0.6.1"
 tiny_http = "0.7.0"
+sha1 = "0.6.0"

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -220,6 +220,31 @@ impl Workspace {
         Ok(())
     }
 
+    /// Remove all the contents of the caches in the workspace, freeing disk space.
+    pub fn purge_all_caches(&self) -> Result<(), Error> {
+        let mut paths = vec![
+            self.cache_dir(),
+            self.cargo_home().join("git"),
+            self.cargo_home().join("registry").join("src"),
+            self.cargo_home().join("registry").join("cache"),
+        ];
+
+        for index in std::fs::read_dir(self.cargo_home().join("registry").join("index"))? {
+            let index = index?;
+            if index.file_type()?.is_dir() {
+                paths.push(index.path().join(".cache"));
+            }
+        }
+
+        for path in &paths {
+            if path.exists() {
+                remove_dir_all(&path)?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Return a list of all the toolchains present in the workspace.
     ///
     /// # Example

--- a/tests/buildtest/crates/process-lines/Cargo.toml
+++ b/tests/buildtest/crates/process-lines/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "process-lines"
+version = "0.1.0"
+authors = ["Pietro Albini <pietro@pietroalbini.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/buildtest/crates/process-lines/src/main.rs
+++ b/tests/buildtest/crates/process-lines/src/main.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("Hello, world!");
+    println!("Hello, world again!");
+}

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -28,7 +28,7 @@ fn test_hello_world() {
 
 #[test]
 fn test_process_lines() {
-    runner::run("hello-world", |run| {
+    runner::run("process-lines", |run| {
         run.build(SandboxBuilder::new().enable_networking(false), |build| {
             let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
             let mut ex = false;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,1 +1,2 @@
 mod crates_git;
+mod purge_caches;

--- a/tests/integration/purge_caches.rs
+++ b/tests/integration/purge_caches.rs
@@ -1,0 +1,103 @@
+use failure::Error;
+use rustwide::cmd::SandboxBuilder;
+use rustwide::{Crate, Toolchain};
+use sha1::{Digest, Sha1};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const WORKSPACE_NAME: &str = "purge-caches";
+
+#[test]
+fn test_purge_caches() -> Result<(), Error> {
+    let workspace_path = crate::utils::workspace_path(WORKSPACE_NAME);
+    let workspace = crate::utils::init_named_workspace(WORKSPACE_NAME)?;
+
+    // Do an initial purge to prevent stale files from being present.
+    workspace.purge_all_build_dirs()?;
+    workspace.purge_all_caches()?;
+
+    let toolchain = Toolchain::dist("stable");
+    toolchain.install(&workspace)?;
+
+    let start_contents = WorkspaceContents::collect(&workspace_path)?;
+
+    let crates = vec![
+        Crate::crates_io("lazy_static", "1.0.0"),
+        Crate::git("https://github.com/pietroalbini/git-credential-null"),
+    ];
+
+    // Simulate a build, which is going to fill up the caches.
+    for krate in &crates {
+        krate.fetch(&workspace)?;
+
+        let sandbox = SandboxBuilder::new().enable_networking(false);
+        let mut build_dir = workspace.build_dir("shared");
+        build_dir.build(&toolchain, krate, sandbox).run(|build| {
+            build.cargo().args(&["check"]).run()?;
+            Ok(())
+        })?;
+    }
+
+    // After all the builds are done purge everything again, and ensure the contents are the same
+    // as when we started.
+    workspace.purge_all_build_dirs()?;
+    workspace.purge_all_caches()?;
+    let end_contents = WorkspaceContents::collect(&workspace_path)?;
+    start_contents.assert_same(end_contents);
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct WorkspaceContents {
+    files: HashMap<PathBuf, Digest>,
+}
+
+impl WorkspaceContents {
+    fn collect(path: &Path) -> Result<Self, Error> {
+        let mut files = HashMap::new();
+
+        for entry in walkdir::WalkDir::new(path) {
+            let entry = entry?;
+            if !entry.metadata()?.is_file() {
+                continue;
+            }
+
+            let mut sha = Sha1::new();
+            sha.update(&std::fs::read(entry.path())?);
+
+            files.insert(entry.path().into(), sha.digest());
+        }
+
+        Ok(Self { files })
+    }
+
+    fn assert_same(self, mut other: Self) {
+        let mut same = true;
+
+        println!("=== start directory differences ===");
+
+        for (path, start_digest) in self.files.into_iter() {
+            if let Some(end_digest) = other.files.remove(&path) {
+                if start_digest != end_digest {
+                    println!("file {} changed", path.display());
+                    same = false;
+                }
+            } else {
+                println!("file {} was removed", path.display());
+                same = false;
+            }
+        }
+
+        for (path, _) in other.files.into_iter() {
+            println!("file {} was added", path.display());
+            same = false;
+        }
+
+        println!("=== end directory differences ===");
+
+        if !same {
+            panic!("the contents of the directory changed");
+        }
+    }
+}

--- a/tests/integration/purge_caches.rs
+++ b/tests/integration/purge_caches.rs
@@ -48,8 +48,32 @@ fn test_purge_caches() -> Result<(), Error> {
     Ok(())
 }
 
+/// Define which files should be ignored when comparing the two workspaces. If there are expected
+/// changes, update the function to match them.
+fn should_ignore(base: &Path, path: &Path) -> bool {
+    let components = match path.strip_prefix(base) {
+        Ok(stripped) => stripped
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().to_string())
+            .collect::<Vec<_>>(),
+        Err(_) => return false,
+    };
+
+    let components = components.iter().map(|c| c.as_str()).collect::<Vec<_>>();
+    match components.as_slice() {
+        // The indexes could be updated during the build. The index is not considered a cache
+        // though, so it's fine to ignore it during the comparison.
+        ["cargo-home", "registry", "index", _, ".git", ..] => true,
+        ["cargo-home", "registry", "index", _, ".cargo-index-lock"] => true,
+        ["cargo-home", "registry", "index", _, ".last-updated"] => true,
+
+        _ => false,
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct WorkspaceContents {
+    base: PathBuf,
     files: HashMap<PathBuf, Digest>,
 }
 
@@ -69,7 +93,10 @@ impl WorkspaceContents {
             files.insert(entry.path().into(), sha.digest());
         }
 
-        Ok(Self { files })
+        Ok(Self {
+            base: path.into(),
+            files,
+        })
     }
 
     fn assert_same(self, mut other: Self) {
@@ -78,6 +105,10 @@ impl WorkspaceContents {
         println!("=== start directory differences ===");
 
         for (path, start_digest) in self.files.into_iter() {
+            if should_ignore(&self.base, &path) {
+                continue;
+            }
+
             if let Some(end_digest) = other.files.remove(&path) {
                 if start_digest != end_digest {
                     println!("file {} changed", path.display());
@@ -90,6 +121,10 @@ impl WorkspaceContents {
         }
 
         for (path, _) in other.files.into_iter() {
+            if should_ignore(&other.base, &path) {
+                continue;
+            }
+
             println!("file {} was added", path.display());
             same = false;
         }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,13 +1,21 @@
 use failure::Error;
 use log::LevelFilter;
 use rustwide::{Workspace, WorkspaceBuilder};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 static USER_AGENT: &str = "rustwide-tests (https://github.com/rust-lang/rustwide)";
 
+pub(crate) fn workspace_path(name: &str) -> PathBuf {
+    Path::new(".workspaces").join(name)
+}
+
 pub(crate) fn init_workspace() -> Result<Workspace, Error> {
+    init_named_workspace("integration")
+}
+
+pub(crate) fn init_named_workspace(name: &str) -> Result<Workspace, Error> {
     init_logs();
-    let workspace_path = Path::new(".workspaces").join("integration");
+    let workspace_path = workspace_path(name);
     let mut builder = WorkspaceBuilder::new(&workspace_path, USER_AGENT).fast_init(true);
 
     if std::env::var("RUSTWIDE_TEST_INSIDE_DOCKER").is_ok() {


### PR DESCRIPTION
This PR adds a method to purge the contents of all the caches, with the goal of freeing up disk space.