### PR TITLE
Allow using an arbitrary Docker image instead of forcing crates-build-env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: all functions and methods inside `cmd` now return `CommandError`.
 - `winapi` is no longer required on unix; `nix` is no longer required on windows.
 - Relaxed lifetime restrictions of `Build::cmd` and `Build::cargo`.
+- The requirement of using an image similar to `crates-build-env` has been
+  lifted, and it's now possible to use any Docker image for the sandbox.
 
 ## [0.9.0] - 2020-07-01
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -389,7 +389,7 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 .cmd(cmd);
 
             if let Some(user) = native::current_user() {
-                builder = builder.env("MAP_USER_ID", user.user_id.to_string());
+                builder = builder.user(user.user_id, user.group_id);
             }
 
             for (key, value) in self.env {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -388,8 +388,8 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 .workdir(container_dirs::WORK_DIR.to_str().unwrap())
                 .cmd(cmd);
 
-            if let Some(user_id) = native::current_user() {
-                builder = builder.env("MAP_USER_ID", user_id.to_string());
+            if let Some(user) = native::current_user() {
+                builder = builder.env("MAP_USER_ID", user.user_id.to_string());
             }
 
             for (key, value) in self.env {

--- a/src/cmd/sandbox.rs
+++ b/src/cmd/sandbox.rs
@@ -143,6 +143,7 @@ pub struct SandboxBuilder {
     memory_limit: Option<usize>,
     cpu_limit: Option<f32>,
     workdir: Option<String>,
+    user: Option<String>,
     cmd: Vec<String>,
     enable_networking: bool,
 }
@@ -156,6 +157,7 @@ impl SandboxBuilder {
             workdir: None,
             memory_limit: None,
             cpu_limit: None,
+            user: None,
             cmd: Vec::new(),
             enable_networking: true,
         }
@@ -216,6 +218,11 @@ impl SandboxBuilder {
         self
     }
 
+    pub(super) fn user(mut self, user: u32, group: u32) -> Self {
+        self.user = Some(format!("{}:{}", user, group));
+        self
+    }
+
     fn create(self, workspace: &Workspace) -> Result<Container<'_>, CommandError> {
         let mut args: Vec<String> = vec!["create".into()];
 
@@ -251,6 +258,11 @@ impl SandboxBuilder {
         if let Some(limit) = self.cpu_limit {
             args.push("--cpus".into());
             args.push(limit.to_string());
+        }
+
+        if let Some(user) = self.user {
+            args.push("--user".into());
+            args.push(user);
         }
 
         if !self.enable_networking {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -7,3 +7,9 @@ pub(crate) use self::unix::*;
 mod windows;
 #[cfg(windows)]
 pub(crate) use self::windows::*;
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(crate) struct CurrentUser {
+    pub(crate) user_id: u32,
+    pub(crate) group_id: u32,
+}

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -1,5 +1,6 @@
+use super::CurrentUser;
 use crate::cmd::KillFailedError;
-use failure::Error;
+use failure::{bail, Error};
 use std::fs::File;
 use std::path::Path;
 use winapi::um::handleapi::CloseHandle;
@@ -25,7 +26,7 @@ pub(crate) fn kill_process(id: u32) -> Result<(), KillFailedError> {
     Ok(())
 }
 
-pub(crate) fn current_user() -> Option<u32> {
+pub(crate) fn current_user() -> Option<CurrentUser> {
     None
 }
 

--- a/tests/buildtest/inside_docker.rs
+++ b/tests/buildtest/inside_docker.rs
@@ -63,10 +63,9 @@ impl CommandExt for Command {
     fn map_user_group(&mut self) -> Result<&mut Self, Error> {
         use std::os::unix::fs::MetadataExt;
         let gid = std::fs::metadata(DOCKER_SOCKET)?.gid();
-        self.arg("-e")
-            .arg(format!("MAP_USER_ID={}", nix::unistd::Uid::effective()))
-            .arg("-e")
-            .arg(format!("MAP_GROUP_ID={}", gid));
+        let uid = nix::unistd::Uid::effective();
+
+        self.arg("--user").arg(format!("{}:{}", uid, gid));
         Ok(self)
     }
 


### PR DESCRIPTION
While Rustwide *technically* already allows to run a build with an arbitrary container image, it forces you to use (a fork of) `crates-build-env` as it integrated with it (through the `MAP_USER_ID` environment variable) to drop privileges inside the container.

This PR lifts that restriction by using Docker's `--user` flag to drop privileges, instead of the entrypoint in `crates-build-env`.