### PR TITLE
Migrate the command module away from failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New variant `CommandError::ExecutionFailed`
+- New variant `CommandError::KillAfterTimeoutFailed`
+- New variant `CommandError::SandboxImagePullFailed`
+- New variant `CommandError::SandboxImageMissing`
+- New variant `CommandError::WorkspaceNotMountedCorrectly`
+- New variant `CommandError::InvalidDockerInspectOutput`
+- New variant `CommandError::IO`
+- New struct `KillFailedError`
+
 ### Changed
 
 - **BREAKING**: support for CI toolchains is now gated behind the
   `unstable-toolchain-ci` Cargo feature.
+- **BREAKING**: all functions and methods inside `cmd` now return `CommandError`.
 - `winapi` is no longer required on unix; `nix` is no longer required on windows.
 - Relaxed lifetime restrictions of `Build::cmd` and `Build::cargo`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ fs2 = "0.4.3"
 remove_dir_all = "0.5.2"
 base64 = "0.12.0"
 getrandom = { version = "0.1.12", features = ["std"] }
+thiserror = "1.0.20"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.11.0"

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -1,21 +1,24 @@
-use failure::{bail, Error};
+use crate::cmd::KillFailedError;
+use failure::Error;
 use std::fs::File;
 use std::path::Path;
 use winapi::um::handleapi::CloseHandle;
 use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess};
 use winapi::um::winnt::PROCESS_TERMINATE;
 
-pub(crate) fn kill_process(id: u32) -> Result<(), Error> {
+pub(crate) fn kill_process(id: u32) -> Result<(), KillFailedError> {
+    let error = Err(KillFailedError { pid: id });
+
     unsafe {
         let handle = OpenProcess(PROCESS_TERMINATE, 0, id);
         if handle.is_null() {
-            bail!("OpenProcess for process {} failed", id);
+            return error;
         }
         if TerminateProcess(handle, 101) == 0 {
-            bail!("TerminateProcess for process {} failed", id);
+            return error;
         }
         if CloseHandle(handle) == 0 {
-            bail!("CloseHandle for process {} failed", id);
+            return error;
         }
     }
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -147,7 +147,7 @@ impl<'a> Prepare<'a> {
                 self.capture_lockfile(true)?;
                 return self.fetch_deps();
             }
-            err => return err,
+            err => return err.map_err(|e| e.into()),
         }
         Ok(())
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -363,7 +363,7 @@ impl Toolchain {
                 .cloned()
                 .collect()),
             Err(_) if not_installed => Err(ToolchainError::NotInstalled.into()),
-            Err(err) => Err(err
+            Err(err) => Err(Error::from(err)
                 .context(format!(
                     "failed to read the list of installed {}s for {} with rustup",
                     thing, name


### PR DESCRIPTION
This PR starts the migration away from `failure` by converting the `cmd` module to the standard `Error` trait (with `thiserror`).