### PR TITLE
Warn when commands are not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - allow workspaces by having validate_manifest now use `metadata --no-deps` instead of deprecated `read-manifest`
   therefor no longer failing on workspaces and TomlTweaker no longer removing the workspace table from `Cargo.toml`
-
+- `Command` now warns when it is not used.
 
 ## [0.10.0] - 2020-08-08
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -188,6 +188,7 @@ impl<'a, B: Runnable> Runnable for &'a B {
 /// output processing, output logging and sandboxing.
 ///
 /// [std]: https://doc.rust-lang.org/std/process/struct.Command.html
+#[must_use = "call `.run()` to run the command"]
 pub struct Command<'w, 'pl> {
     workspace: Option<&'w Workspace>,
     sandbox: Option<SandboxBuilder>,


### PR DESCRIPTION
I ran into bugs in docs.rs because of unused commands.

```
warning: unused `rustwide::cmd::Command` that must be used
   --> src/docbuilder/rustwide_builder.rs:591:9
    |
591 |         build.cmd("mkdir").args(&["iPhoneOS.platform"]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: call `.run()` to run the command
```