### PR TITLE
Workaround iOS bugs in rustc

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -244,7 +244,8 @@ impl<'w, 'pl> Command<'w, 'pl> {
             sandbox,
             binary,
             args: Vec::new(),
-            env: Vec::new(),
+            // Workaround for https://github.com/rust-lang/rust/issues/76584
+            env: vec![("SDKROOT".into(), "iPhoneOS.platform".into())],
             process_lines: None,
             cd: None,
             timeout,

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -43,6 +43,7 @@ impl<'a> Prepare<'a> {
         self.tweak_toml()?;
         self.capture_lockfile(false)?;
         self.fetch_deps()?;
+        self.create_ios_sdkroot()?;
 
         Ok(())
     }
@@ -150,6 +151,10 @@ impl<'a> Prepare<'a> {
             err => return err.map_err(|e| e.into()),
         }
         Ok(())
+    }
+
+    fn create_ios_sdkroot(&mut self) -> Result<(), Error> {
+        Command::new(self.workspace, "mkdir").args(&["iPhoneOS.platform"]).run().map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Does `crater` ever cross-compile? I didn't see code for it in rustwide, I don't know where to add a test.

Follow-up to https://github.com/rust-lang/docs.rs/pull/1058 (untested)