### PR TITLE
Switch from reqwest to attohttpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,17 @@ unstable = []
 unstable-toolchain-ci = []
 
 [dependencies]
+http = "0.2"
 failure = "0.1.3"
 futures-util = "0.3.5"
 log = "0.4.6"
-tokio = { version = "0.2.21", features = ["process", "time"] }
+tokio = { version = "0.2.21", features = ["process", "time", "io-util", "stream", "rt-core", "rt-threaded"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 scopeguard = "1.0.0"
 lazy_static = "1.0.0"
 tempfile = "3.0.0"
-reqwest = { version = "0.10.4", features = ["blocking"] }
+attohttpc = "0.16"
 flate2 = "1"
 tar = "0.4.0"
 percent-encoding = "2.1.0"

--- a/src/crates/registry.rs
+++ b/src/crates/registry.rs
@@ -134,12 +134,12 @@ impl CrateTrait for RegistryCrate {
             std::fs::create_dir_all(parent)?;
         }
 
-        let mut resp = workspace
+        workspace
             .http_client()
             .get(&self.fetch_url(workspace)?)
             .send()?
-            .error_for_status()?;
-        resp.copy_to(&mut BufWriter::new(File::create(&local)?))?;
+            .error_for_status()?
+            .write_to(&mut BufWriter::new(File::create(&local)?))?;
 
         Ok(())
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -149,15 +149,12 @@ impl WorkspaceBuilder {
                 SandboxImage::remote(DEFAULT_SANDBOX_IMAGE)?
             };
 
-            let mut headers = reqwest::header::HeaderMap::new();
-            headers.insert(reqwest::header::USER_AGENT, self.user_agent.parse()?);
-            let http = reqwest::blocking::ClientBuilder::new()
-                .default_headers(headers)
-                .build()?;
+            let mut agent = attohttpc::Session::new();
+            agent.header(http::header::USER_AGENT, self.user_agent);
 
             let mut ws = Workspace {
                 inner: Arc::new(WorkspaceInner {
-                    http,
+                    http: agent,
                     path: self.path,
                     sandbox_image,
                     command_timeout: self.command_timeout,
@@ -180,7 +177,7 @@ impl WorkspaceBuilder {
 }
 
 struct WorkspaceInner {
-    http: reqwest::blocking::Client,
+    http: attohttpc::Session,
     path: PathBuf,
     sandbox_image: SandboxImage,
     command_timeout: Option<Duration>,
@@ -266,7 +263,7 @@ impl Workspace {
         crate::toolchain::list_installed_toolchains(&self.rustup_home())
     }
 
-    pub(crate) fn http_client(&self) -> &reqwest::blocking::Client {
+    pub(crate) fn http_client(&self) -> &attohttpc::Session {
         &self.inner.http
     }
 


### PR DESCRIPTION
This cuts down compile times by 10 seconds out of a 35 second build.

Before: https://jyn514.github.io/assets/cargo-timing-reqwest.html
After: https://jyn514.github.io/assets/cargo-timing-attohttpc.html