### PR TITLE
Allow running arbitrary binaries through rustup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New method `Toolchain::rustup_binary` to allow running arbitrary binaries managed by rustup. Before, only `rustc` and `cargo` could be run.
+
 ## [0.12.0] - 2021-01-28
 
 ### Added
 
 - New variant `PrepareError::MissingDependencies`, returned during the prepare
   step when a dependency does not exist.
-
 ### Changed
 
 - Path dependencies are no longer removed from `Cargo.toml` during the prepare

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -400,10 +400,7 @@ impl Toolchain {
     /// # }
     /// ```
     pub fn cargo(&self) -> impl Runnable + '_ {
-        RustupProxy {
-            toolchain: self,
-            name: "cargo",
-        }
+        self.rustup_binary("cargo")
     }
 
     /// Return a runnable object configured to run `rustc` with this toolchain. This method is
@@ -424,9 +421,29 @@ impl Toolchain {
     /// # }
     /// ```
     pub fn rustc(&self) -> impl Runnable + '_ {
+        self.rustup_binary("rustc")
+    }
+
+    /// Return a runnable object configured to run `name` with this toolchain. This method is
+    /// intended to be used with [`rustwide::cmd::Command`](cmd/struct.Command.html).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use rustwide::{WorkspaceBuilder, Toolchain, cmd::Command};
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let workspace = WorkspaceBuilder::new("".as_ref(), "").init()?;
+    /// let toolchain = Toolchain::dist("beta");
+    /// Command::new(&workspace, toolchain.rustup_binary("rustdoc"))
+    ///     .args(&["hello.rs"])
+    ///     .run()?;
+    /// # Ok(())
+    /// # }
+    pub fn rustup_binary(&self, name: &'static str) -> impl Runnable + '_ {
         RustupProxy {
             toolchain: self,
-            name: "rustc",
+            name,
         }
     }
 


### PR DESCRIPTION
Currently, `Toolchain` only allows running a set list of binaries (rustc
and cargo). This allows running arbitrary binaries, like rustdoc or
rustfmt.

r? @pietroalbini 