### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ walkdir = "2.2"
 toml = "0.5"
 fs2 = "0.4.3"
 remove_dir_all = "0.5.2"
-base64 = "0.12.0"
+base64 = "0.13.0"
 getrandom = { version = "0.1.12", features = ["std"] }
 thiserror = "1.0.20"
 git2 = "0.13.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,18 +36,18 @@ percent-encoding = "2.1.0"
 walkdir = "2.2"
 toml = "0.5"
 fs2 = "0.4.3"
-remove_dir_all = "0.5.2"
+remove_dir_all = "0.7"
 base64 = "0.13.0"
-getrandom = { version = "0.1.12", features = ["std"] }
+getrandom = { version = "0.2", features = ["std"] }
 thiserror = "1.0.20"
 git2 = "0.13.12"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.11.0"
+nix = "0.20.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
 
 [dev-dependencies]
-env_logger = "0.6.1"
-tiny_http = "0.7.0"
+env_logger = "0.8"
+tiny_http = "0.8.0"

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn init_named_workspace(name: &str) -> Result<Workspace, Error> {
 fn init_logs() {
     let env = env_logger::Builder::new()
         .filter_module("rustwide", LevelFilter::Info)
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .is_test(true)
         .build();
     rustwide::logging::init_with(env);


### PR DESCRIPTION
In particular, updating base64 removes a duplicate dependency for docs.rs.