### PR TITLE
Add support for path-based patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New method `BuildBuilder::patch_with_path()` for path-based patching (as compared to git-based).
+
 ## [0.14.0] - 2021-08-19
 
 ### Added

--- a/tests/buildtest/crates/path-based-patch/Cargo.toml
+++ b/tests/buildtest/crates/path-based-patch/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "path-based-patch"
+version = "0.1.0"
+authors = ["Pietro Albini <pietro@pietroalbini.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+empty-library = "1.0.0"

--- a/tests/buildtest/crates/path-based-patch/patch/Cargo.toml
+++ b/tests/buildtest/crates/path-based-patch/patch/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "empty-library"
+version = "1.0.1"
+authors = ["Pietro Albini <pietro@pietroalbini.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/buildtest/crates/path-based-patch/patch/src/lib.rs
+++ b/tests/buildtest/crates/path-based-patch/patch/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn dummy() {
+    println!("This is coming from the patch!");
+}

--- a/tests/buildtest/crates/path-based-patch/src/main.rs
+++ b/tests/buildtest/crates/path-based-patch/src/main.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("Hello, world!");
+    empty_library::dummy();
+}

--- a/tests/buildtest/inside_docker.rs
+++ b/tests/buildtest/inside_docker.rs
@@ -15,6 +15,12 @@ fn test_hello_world() {
     execute("buildtest::test_hello_world").unwrap();
 }
 
+#[test]
+#[cfg(unix)]
+fn test_path_based_patch() {
+    execute("buildtest::path_based_patch").unwrap();
+}
+
 fn execute(test: &str) -> Result<(), Error> {
     // The current working directory is mounted in the container to /outside.
     // The binary to execute is remapped to be prefixed by /outside instead of the current

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -27,6 +27,30 @@ fn test_hello_world() {
 }
 
 #[test]
+fn path_based_patch() {
+    runner::run("path-based-patch", |run| {
+        run.build(SandboxBuilder::new().enable_networking(false), |builder| {
+            builder
+                .patch_with_path("empty-library", "./patch")
+                .run(move |build| {
+                    let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
+                    rustwide::logging::capture(&storage, || -> Result<_, Error> {
+                        build.cargo().args(&["run"]).run()?;
+                        Ok(())
+                    })?;
+
+                    assert!(storage.to_string().contains("[stdout] Hello, world!\n"));
+                    assert!(storage
+                        .to_string()
+                        .contains("[stdout] This is coming from the patch!\n"));
+                    Ok(())
+                })
+        })?;
+        Ok(())
+    });
+}
+
+#[test]
 fn test_process_lines() {
     runner::run("process-lines", |run| {
         run.run(SandboxBuilder::new().enable_networking(false), |build| {

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -9,7 +9,7 @@ mod inside_docker;
 #[test]
 fn test_hello_world() {
     runner::run("hello-world", |run| {
-        run.build(SandboxBuilder::new().enable_networking(false), |build| {
+        run.run(SandboxBuilder::new().enable_networking(false), |build| {
             let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
             rustwide::logging::capture(&storage, || -> Result<_, Error> {
                 build.cargo().args(&["run"]).run()?;
@@ -29,7 +29,7 @@ fn test_hello_world() {
 #[test]
 fn test_process_lines() {
     runner::run("process-lines", |run| {
-        run.build(SandboxBuilder::new().enable_networking(false), |build| {
+        run.run(SandboxBuilder::new().enable_networking(false), |build| {
             let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
             let mut ex = false;
             rustwide::logging::capture(&storage, || -> Result<_, Error> {
@@ -64,7 +64,7 @@ fn test_sandbox_oom() {
     use rustwide::cmd::CommandError;
 
     runner::run("out-of-memory", |run| {
-        let res = run.build(
+        let res = run.run(
             SandboxBuilder::new()
                 .enable_networking(false)
                 .memory_limit(Some(512 * 1024 * 1024)),
@@ -85,7 +85,7 @@ fn test_sandbox_oom() {
 #[test]
 fn test_override_files() {
     runner::run("cargo-config", |run| {
-        run.build(SandboxBuilder::new().enable_networking(false), |build| {
+        run.run(SandboxBuilder::new().enable_networking(false), |build| {
             let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
             rustwide::logging::capture(&storage, || -> Result<_, Error> {
                 build.cargo().args(&["--version"]).run()?;
@@ -104,7 +104,7 @@ fn test_override_files() {
 #[test]
 fn test_cargo_workspace() {
     runner::run("cargo-workspace", |run| {
-        run.build(SandboxBuilder::new().enable_networking(false), |build| {
+        run.run(SandboxBuilder::new().enable_networking(false), |build| {
             let storage = rustwide::logging::LogStorage::new(LevelFilter::Info);
             rustwide::logging::capture(&storage, || -> Result<_, Error> {
                 build.cargo().args(&["run"]).run()?;


### PR DESCRIPTION
Combined with a sandbox mount this allows for patching with a local file path, instead of a remote git repo branch.