### PR TITLE
Delete all installed toolchains when clearing caches

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -236,6 +236,10 @@ impl Workspace {
             }
         }
 
+        for toolchain in self.installed_toolchains()? {
+            toolchain.uninstall(self)?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Toolchains are essentially also cached; we should ensure their deletion.

On crater, this would save (after purging):

* 55 GB crater-gcp-1
* 55 GB crater-gcp-2
* 125 GB crater-azure-1
* 80 GB crater-azure-2

I am not sure if this patch is the right idea; it might be that bits of rustwide rely on toolchains existing after purge_all_caches is run. If so, we can uninstall in crater rather than relying on this function's purging...
