### PR TITLE
Use crates-build-env from GHCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New method `Toolchain::rustup_binary` to allow running arbitrary binaries managed by rustup. Before, only `rustc` and `cargo` could be run.
 
+### Changed
+
+- The default sandbox image is now fetched from [GitHub Container Registry][ghcr-linux].
+
+[ghcr-linux]: https://github.com/orgs/rust-lang/packages/container/package/crates-build-env/linux
+
 ## [0.12.0] - 2021-01-28
 
 ### Added
 
 - New variant `PrepareError::MissingDependencies`, returned during the prepare
   step when a dependency does not exist.
+
 ### Changed
 
 - Path dependencies are no longer removed from `Cargo.toml` during the prepare

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 static DEFAULT_SANDBOX_IMAGE: &str = "rustops/crates-build-env-windows";
 
 #[cfg(not(windows))]
-static DEFAULT_SANDBOX_IMAGE: &str = "rustops/crates-build-env";
+static DEFAULT_SANDBOX_IMAGE: &str = "ghcr.io/rust-lang/crates-build-env/linux";
 
 const DEFAULT_COMMAND_TIMEOUT: Option<Duration> = Some(Duration::from_secs(15 * 60));
 const DEFAULT_COMMAND_NO_OUTPUT_TIMEOUT: Option<Duration> = None;
@@ -53,11 +53,11 @@ impl WorkspaceBuilder {
 
     /// Override the image used for sandboxes.
     ///
-    /// By default rustwide will use the [rustops/crates-build-env] image on Linux systems, and
-    /// [rustops/crates-build-env-windows] on Windows systems. Those images contain dependencies to
-    /// build a large amount of crates.
+    /// By default rustwide will use the [ghcr.io/rust-lang/crates-build-env/linux-micro] image on
+    /// Linux systems, and [rustops/crates-build-env-windows] on Windows systems. Those images
+    /// contain dependencies to build a large amount of crates.
     ///
-    /// [rustops/crates-build-env]: https://hub.docker.com/r/rustops/crates-build-env
+    /// [ghcr.io/rust-lang/crates-build-env/linux-micro]: https://github.com/orgs/rust-lang/packages/container/package/crates-build-env/linux-micro
     /// [rustops/crates-build-env-windows]: https://hub.docker.com/r/rustops/crates-build-env-windows
     pub fn sandbox_image(mut self, image: SandboxImage) -> Self {
         self.sandbox_image = Some(image);

--- a/tests/buildtest/inside_docker.rs
+++ b/tests/buildtest/inside_docker.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
-static DOCKER_IMAGE_TAG: &str = "rustops/crates-build-env";
+static DOCKER_IMAGE_TAG: &str = "ghcr.io/rust-lang/crates-build-env/linux-micro";
 static DOCKER_SOCKET: &str = "/var/run/docker.sock";
 static CONTAINER_PREFIX: &str = "/outside";
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use failure::Error;
 use log::LevelFilter;
-use rustwide::{Workspace, WorkspaceBuilder};
+use rustwide::{cmd::SandboxImage, Workspace, WorkspaceBuilder};
 use std::path::{Path, PathBuf};
 
 static USER_AGENT: &str = "rustwide-tests (https://github.com/rust-lang/rustwide)";
@@ -20,6 +20,13 @@ pub(crate) fn init_named_workspace(name: &str) -> Result<Workspace, Error> {
 
     if std::env::var("RUSTWIDE_TEST_INSIDE_DOCKER").is_ok() {
         builder = builder.running_inside_docker(true);
+    }
+
+    // Use the micro image when running tests on Linux, speeding them up.
+    if cfg!(target_os = "linux") {
+        builder = builder.sandbox_image(SandboxImage::remote(
+            "ghcr.io/rust-lang/crates-build-env/linux-micro",
+        )?);
     }
 
     builder.init()


### PR DESCRIPTION
This PR switches Rustwide to use the `crates-build-env` image uploaded to GHCR instead of downloading it from Docker Hub. In addition to that, it now uses the new `linux-micro` image to run tests, hopefully speeding up running the test suite. 