### PR TITLE
Update git2 to compile with latest rustc nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ remove_dir_all = "0.7"
 base64 = "0.13.0"
 getrandom = { version = "0.2", features = ["std"] }
 thiserror = "1.0.20"
-git2 = "0.13.12"
+git2 = "0.13.20"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.20.0"


### PR DESCRIPTION
This should work around the issue rust-lang/rust#85574 by including https://github.com/rust-lang/git2-rs/pull/712.

(I haven't tested this change locally.)
