### PR TITLE
Add method to Toolchain to help crater know what to uninstall.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New method `Toolchain::is_needed_by_rustwide` for checking if a toolchain
+  is needed by rustwide itself (for installing tools).
+
 ## [0.13.1] - 2021-05-21
 
 ### Changed

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -178,6 +178,25 @@ impl Toolchain {
         }),
     };
 
+    /// Returns whether or not this toolchain is needed by rustwide itself.
+    ///
+    /// This toolchain is used for doing things like installing tools.
+    ///
+    /// ```rust
+    /// # use rustwide::Toolchain;
+    /// let tc = Toolchain::dist("stable-x86_64-unknown-linux-gnu");
+    /// assert!(tc.is_needed_by_rustwide());
+    /// let tc = Toolchain::dist("nightly-x86_64-unknown-linux-gnu");
+    /// assert!(!tc.is_needed_by_rustwide());
+    /// ```
+    pub fn is_needed_by_rustwide(&self) -> bool {
+        match &self.inner {
+            ToolchainInner::Dist(dist) => dist.name.starts_with(MAIN_TOOLCHAIN_NAME),
+            #[cfg(feature = "unstable-toolchain-ci")]
+            _ => false,
+        }
+    }
+
     /// Create a new dist toolchain.
     ///
     /// Dist toolchains are all the toolchains available through rustup and distributed from


### PR DESCRIPTION
This adds a method to `Toolchain` to help crater know whether or not to uninstall a toolchain (see https://github.com/rust-lang/crater/pull/584).
