### PR TITLE
Fetch dependencies for `-Zbuild-std` before entering the sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New method `Build::fetch_build_std_dependencies` for using `-Zbuild-std` within the sandbox when
+  networking is disabled. Previously, this would try to fetch the standard library sources, which
+  would error when networking was blocked.
+
 ## [0.15.2] - 2022-11-08
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,5 @@ windows-sys = {version = "0.36.1", features = ["Win32_Foundation", "Win32_System
 
 [dev-dependencies]
 env_logger = "0.8"
+rand = "0.8.5"
 tiny_http = "0.8.0"

--- a/src/build.rs
+++ b/src/build.rs
@@ -314,4 +314,20 @@ impl<'ws> Build<'ws> {
     pub fn host_target_dir(&self) -> PathBuf {
         self.dir.target_dir()
     }
+
+    /// Pre-fetching the dependencies for `-Z build-std` outside the sandbox.
+    ///
+    /// When this function is called, it is possible to use `-Zbuild-std` inside
+    /// the sandbox to build the standard library from source even when
+    /// networking is disabled.
+    #[cfg(any(feature = "unstable", doc))]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "unstable")))]
+    pub fn fetch_build_std_dependencies(&self, targets: &[&str]) -> Result<(), Error> {
+        crate::prepare::fetch_deps(
+            &self.dir.workspace,
+            self.toolchain,
+            &self.host_source_dir(),
+            targets,
+        )
+    }
 }


### PR DESCRIPTION
This allows running `doc -Zbuild-std` from within the sandbox.
Previously, it would error out because cargo tried to download the
standard library's dependencies:

```
[2021-11-27T19:57:24Z INFO  rustwide::cmd] running `Command { std: "docker" "create" "-v" "/home/joshua/src/rust/docs.rs/.workspace/builds/gba-0.5.2/target:/opt/rustwide/target:rw,Z" "-v" "/home/joshua/src/rust/docs.rs/.workspace/builds/gba-0.5.2/source:/opt/rustwide/workdir:ro,Z" "-v" "/home/joshua/src/rust/docs.rs/.workspace/cargo-home:/opt/rustwide/cargo-home:ro,Z" "-v" "/home/joshua/src/rust/docs.rs/.workspace/rustup-home:/opt/rustwide/rustup-home:ro,Z" "-e" "SOURCE_DIR=/opt/rustwide/workdir" "-e" "CARGO_TARGET_DIR=/opt/rustwide/target" "-e" "DOCS_RS=1" "-e" "CARGO_HOME=/opt/rustwide/cargo-home" "-e" "RUSTUP_HOME=/opt/rustwide/rustup-home" "-w" "/opt/rustwide/workdir" "-m" "3221225472" "--user" "1000:1000" "--network" "none" "ghcr.io/rust-lang/crates-build-env/linux-micro" "/opt/rustwide/cargo-home/bin/cargo" "+nightly" "rustdoc" "--lib" "-Zrustdoc-map" "-Z" "unstable-options" "--config" "build.rustdocflags=[\"--cfg\", \"docs_rs\", \"-Z\", \"unstable-options\", \"--emit=invocation-specific\", \"--resource-suffix\", \"-20211126-1.58.0-nightly-6d246f0c8\", \"--static-root-path\", \"/\", \"--cap-lints\", \"warn\", \"--disable-per-crate-search\"]" "-Zunstable-options" "--config=doc.extern-map.registries.crates-io=\"https://docs.rs/{pkg_name}/{version}/thumbv4t-none-eabi\"" "-Zbuild-std" "--target" "thumbv4t-none-eabi", kill_on_drop: false }`
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stdout] fe2773f8a17ab13ce7b66c7221f91883a7b92b3bdeef7b30bf2ed55aa6b3d511
[2021-11-27T19:57:24Z INFO  rustwide::cmd] running `Command { std: "docker" "start" "-a" "fe2773f8a17ab13ce7b66c7221f91883a7b92b3bdeef7b30bf2ed55aa6b3d511", kill_on_drop: false }`
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stderr]  Downloading crates ...
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stderr] warning: spurious network error (2 tries remaining): [6] Couldn't resolve host name (Could not resolve host: crates.io)
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stderr] error: failed to download from `https://crates.io/api/v1/crates/libc/0.2.106/download`
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stderr]
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stderr] Caused by:
[2021-11-27T19:57:24Z INFO  rustwide::cmd] [stderr]   [6] Couldn't resolve host name (Could not resolve host: crates.io)
```

This is currently blocked on https://github.com/rust-lang/cargo/pull/10129 to make `-Zbuild-std` actually have an effect.