### PR TITLE
upgrade git2 to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ remove_dir_all = "0.7"
 base64 = "0.13.0"
 getrandom = { version = "0.2", features = ["std"] }
 thiserror = "1.0.20"
-git2 = "0.13.12"
+git2 = "0.14.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.20.0"

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -109,7 +109,7 @@ pub enum CommandError {
 #[derive(Debug, thiserror::Error)]
 #[cfg_attr(unix, error(
     "failed to kill the process with PID {pid}{}",
-    .errno.map(|e| format!(": {}", e.desc())).unwrap_or_else(String::new)
+    .errno.map(|e| format!(": {}", e.desc())).unwrap_or_default()
 ))]
 #[cfg_attr(not(unix), error("failed to kill the process with PID {pid}"))]
 pub struct KillFailedError {


### PR DESCRIPTION
I was upgrading dependencies for in docs.rs, and stumbled onto this issue. 

Problem is that `git2` upgraded `libgit2-sys` to `1.4.0`, which then leads to a conflict (_failed to select a version for `libgit2-sys`_) when an application has any older version of `git` in the dependency tree. 

See also: 
- https://github.com/frewsxcv/rust-crates-index/pull/78
- https://github.com/Byron/crates-index-diff-rs/pull/13