### PR TITLE
Migrate from winapi to windows-rs by microsoft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ git2 = "0.14.0"
 nix = "0.20.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+windows-sys = {version = "0.36.1", features = ["Win32_Foundation", "Win32_System_Threading"]}
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -3,16 +3,15 @@ use crate::cmd::KillFailedError;
 use failure::{bail, Error};
 use std::fs::File;
 use std::path::Path;
-use winapi::um::handleapi::CloseHandle;
-use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess};
-use winapi::um::winnt::PROCESS_TERMINATE;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
 
 pub(crate) fn kill_process(id: u32) -> Result<(), KillFailedError> {
     let error = Err(KillFailedError { pid: id });
 
     unsafe {
         let handle = OpenProcess(PROCESS_TERMINATE, 0, id);
-        if handle.is_null() {
+        if handle == 0 {
             return error;
         }
         if TerminateProcess(handle, 101) == 0 {

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -11,7 +11,7 @@ pub(crate) fn kill_process(id: u32) -> Result<(), KillFailedError> {
 
     unsafe {
         let handle = OpenProcess(PROCESS_TERMINATE, 0, id);
-        if handle == 0 {
+        if handle == 0 || handle == -1 {
             return error;
         }
         if TerminateProcess(handle, 101) == 0 {


### PR DESCRIPTION
Move from `winapi` to `windows_sys` considering `winapi` is no longer actively maintained compared to `windows-rs`

- [X] Builds
- [X] Passes tests except the last one which it fails without making any changes either