### PR TITLE
Allow installing targets & components for CI toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.15.2] - 2022-10-13
+
+### Changed
+
+* CI toolchains can now install additional targets and components.
+
 ## [0.15.1] - 2022-09-04
 
 ### Changed
@@ -286,6 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version of Rustwide, extracted from Crater.
 
+[0.15.2]: https://github.com/rust-lang/rustwide/releases/tag/0.15.2
 [0.15.1]: https://github.com/rust-lang/rustwide/releases/tag/0.15.1
 [0.15.0]: https://github.com/rust-lang/rustwide/releases/tag/0.15.0
 [0.14.0]: https://github.com/rust-lang/rustwide/releases/tag/0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwide"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2018"
 build = "build.rs"
 

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -1,6 +1,6 @@
 use super::CurrentUser;
 use crate::cmd::KillFailedError;
-use failure::{bail, Error};
+use failure::Error;
 use std::fs::File;
 use std::path::Path;
 use windows_sys::Win32::Foundation::CloseHandle;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -541,7 +541,7 @@ pub(crate) fn list_installed_toolchains(rustup_home: &Path) -> Result<Vec<Toolch
             #[cfg(feature = "unstable-toolchain-ci")]
             {
                 let (sha, alt) = if name.ends_with("-alt") {
-                    ((&name[..name.len() - 4]).to_string(), true)
+                    ((name[..name.len() - 4]).to_string(), true)
                 } else {
                     (name, false)
                 };

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -315,23 +315,48 @@ impl Toolchain {
             RustupAction::Remove => ("remove", "removing"),
         };
 
-        let thing = thing.to_string();
-        let action = action.to_string();
+        let toolchain_name = self.rustup_name();
+        info!("{log_action_ing} {thing} {name} for toolchain {toolchain_name}");
 
         #[cfg(feature = "unstable-toolchain-ci")]
-        if let ToolchainInner::CI { .. } = self.inner {
-            failure::bail!(
-                "{} {} on CI toolchains is not supported yet",
-                log_action_ing,
-                thing
-            );
+        if let ToolchainInner::CI(ci) = &self.inner {
+            if let RustupAction::Remove = action {
+                failure::bail!("removing {thing} on CI toolchains is not supported yet");
+            }
+
+            let mut args = Vec::with_capacity(6);
+            if ci.alt {
+                args.push("--alt");
+            }
+            args.extend([
+                // `-f` is required otherwise rustup-toolchain-install-master will early return
+                // because the toolchain (but not the new component) is already installed.
+                "-f",
+                match thing {
+                    RustupThing::Target => "--targets",
+                    RustupThing::Component => "--component",
+                },
+                name,
+                // We have to pass `--` otherwise the sha is interpreted as a target name.
+                "--",
+                &ci.sha,
+            ]);
+
+            Command::new(workspace, &RUSTUP_TOOLCHAIN_INSTALL_MASTER)
+                .args(&args)
+                .run()
+                .with_context(|_| {
+                    format!(
+                        "unable to {log_action} {thing} {name} for CI toolchain {toolchain_name} \
+                            via rustup-toolchain-install-master"
+                    )
+                })?;
+
+            return Ok(());
         }
 
-        let toolchain_name = self.rustup_name();
-        info!(
-            "{} {} {} for toolchain {}",
-            log_action_ing, thing, name, toolchain_name
-        );
+        let thing = thing.to_string();
+        let action = action.to_string();
 
         Command::new(workspace, &RUSTUP)
             .args(&[
@@ -344,8 +369,7 @@ impl Toolchain {
             .run()
             .with_context(|_| {
                 format!(
-                    "unable to {} {} {} for toolchain {} via rustup",
-                    log_action, thing, name, toolchain_name,
+                    "unable to {log_action} {thing} {name} for toolchain {toolchain_name} via rustup"
                 )
             })?;
         Ok(())


### PR DESCRIPTION
With this change, crater is able to successfully install alternative targets for use with the `+target` modifier syntax.

While this works fine for crater, this doesn't work in the more general case as the API allows you to call it multiple times with the assumption being that doing so leaves the existing targets and components around and only installs the newly requested target/component. `rustup-toolchain-install-master` doesn't support this and instead replaces the previous state of the toolchain with the newly requested one.

As a result, calling `add_target("foo"); add_target("bar");` leaves only the `bar` target installed.

Since installing CI toolchains is gated behind the unstable feature flag, I think this is ok for now.