### PR TITLE
Fix test failure in the purge_caches test

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -465,7 +465,7 @@ impl<'w, 'pl> Command<'w, 'pl> {
                     crate::utils::normalize_path(rustup_home.as_ref()),
                 );
             }
-            for &(ref k, ref v) in &self.env {
+            for (k, v) in &self.env {
                 cmd.env(k, v);
             }
 

--- a/src/cmd/process_lines_actions.rs
+++ b/src/cmd/process_lines_actions.rs
@@ -1,16 +1,12 @@
 use std::default::Default;
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Default)]
 pub(super) enum InnerState {
     Removed,
+    #[default]
     Original,
     Replaced(Vec<String>),
-}
-
-impl Default for InnerState {
-    fn default() -> Self {
-        InnerState::Original
-    }
 }
 
 /// Represents actions that are available while reading live output from a process.

--- a/src/cmd/sandbox.rs
+++ b/src/cmd/sandbox.rs
@@ -240,7 +240,7 @@ impl SandboxBuilder {
             }
         }
 
-        for &(ref var, ref value) in &self.env {
+        for (var, value) in &self.env {
             args.push("-e".into());
             args.push(format! {"{}={}", var, value})
         }

--- a/src/crates/registry.rs
+++ b/src/crates/registry.rs
@@ -165,7 +165,7 @@ impl CrateTrait for RegistryCrate {
 
         workspace
             .http_client()
-            .get(&self.fetch_url(workspace)?)
+            .get(self.fetch_url(workspace)?)
             .send()?
             .error_for_status()?
             .write_to(&mut BufWriter::new(File::create(&local)?))?;
@@ -230,7 +230,7 @@ fn unpack_without_first_dir<R: Read>(archive: &mut Archive<R>, path: &Path) -> R
         let mut components = relpath.components();
         // Throw away the first path component
         components.next();
-        let full_path = path.join(&components.as_path());
+        let full_path = path.join(components.as_path());
         if let Some(parent) = full_path.parent() {
             std::fs::create_dir_all(parent)?;
         }

--- a/src/inside_docker.rs
+++ b/src/inside_docker.rs
@@ -69,7 +69,7 @@ pub(crate) fn probe_container_id(workspace: &Workspace) -> Result<Option<String>
             .log_output(false)
             .log_command(false)
             .run_capture();
-        if let Ok(&[ref probed]) = res.as_ref().map(|out| out.stdout_lines()) {
+        if let Ok([probed]) = res.as_ref().map(|out| out.stdout_lines()) {
             if *probed == probe_content {
                 info!("probe successful, this is container ID {}", id);
                 return Ok(Some(id.clone()));

--- a/src/native/unix.rs
+++ b/src/native/unix.rs
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn test_kill_process() {
         // Try to kill a sleep command
-        let mut cmd = Command::new("sleep").args(&["2"]).spawn().unwrap();
+        let mut cmd = Command::new("sleep").args(["2"]).spawn().unwrap();
         super::kill_process(cmd.id()).unwrap();
 
         // Ensure it was killed with SIGKILL

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -141,7 +141,7 @@ impl<'a> Prepare<'a> {
         let mut missing_deps = false;
         let res = Command::new(self.workspace, self.toolchain.cargo())
             .args(&["fetch", "--manifest-path", "Cargo.toml"])
-            .cd(&self.source_dir)
+            .cd(self.source_dir)
             .process_lines(&mut |line, _| {
                 if line.contains("failed to load source for dependency") {
                     missing_deps = true;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -595,10 +595,7 @@ mod tests {
         // Create a fake rustup-installed toolchain
         std::fs::create_dir_all(rustup_home.path().join("toolchains").join(DIST_NAME))?;
         std::fs::create_dir_all(rustup_home.path().join("update-hashes"))?;
-        std::fs::write(
-            rustup_home.path().join("update-hashes").join(DIST_NAME),
-            &[],
-        )?;
+        std::fs::write(rustup_home.path().join("update-hashes").join(DIST_NAME), [])?;
 
         // Create a fake symlinked toolchain
         #[cfg(unix)]

--- a/src/tools/rustup.rs
+++ b/src/tools/rustup.rs
@@ -44,7 +44,7 @@ impl Tool for Rustup {
         );
         let mut resp = workspace
             .http_client()
-            .get(&url)
+            .get(url)
             .send()?
             .error_for_status()?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ fn strip_verbatim_from_prefix(prefix: &PrefixComponent<'_>) -> Option<PathBuf> {
 }
 
 pub(crate) fn remove_file(path: &Path) -> std::io::Result<()> {
-    std::fs::remove_file(&path).map_err(|error| crate::utils::improve_remove_error(error, path))
+    std::fs::remove_file(path).map_err(|error| crate::utils::improve_remove_error(error, path))
 }
 
 pub(crate) fn remove_dir_all(path: &Path) -> std::io::Result<()> {

--- a/tests/buildtest/inside_docker.rs
+++ b/tests/buildtest/inside_docker.rs
@@ -43,7 +43,7 @@ fn execute(test: &str) -> Result<(), Error> {
         .arg("-v")
         .arg(docker_sock)
         .arg("-w")
-        .arg(&container_prefix)
+        .arg(container_prefix)
         .arg("-e")
         .arg("RUST_BACKTRACE=1")
         .arg("-e")

--- a/tests/integration/purge_caches.rs
+++ b/tests/integration/purge_caches.rs
@@ -21,7 +21,7 @@ fn test_purge_caches() -> Result<(), Error> {
     let start_contents = WorkspaceContents::collect(&workspace_path)?;
 
     let crates = vec![
-        Crate::crates_io("lazy_static", "1.0.0"),
+        Crate::crates_io("lazy_static", "1.4.0"),
         Crate::git("https://github.com/pietroalbini/git-credential-null"),
     ];
 


### PR DESCRIPTION
The failure with the older `lazy_static` version happened locally when running the test suite.