### PR TITLE
upgrade git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ remove_dir_all = "0.7"
 base64 = "0.13.0"
 getrandom = { version = "0.2", features = ["std"] }
 thiserror = "1.0.20"
-git2 = "0.14.0"
+git2 = "0.17.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.25.0"


### PR DESCRIPTION
I would like to upgrade `crates-index` for docs.rs, which is blocked by rustwide linking to another `git2` version. 