### PR TITLE
add max_line_length to LogStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New method `LogStorage::set_max_line_length` to limit the logged line length when capturing
+  builds logs
+
 ## [0.16.0] - 2023-05-02
 
 ### Added
@@ -17,14 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* CI toolchains can now install additional targets and components.
+- CI toolchains can now install additional targets and components.
 
 ## [0.15.1] - 2022-09-04
 
 ### Changed
 
-* Updated `nix` dependency to 0.25.
-* Replaced `winapi` dependency with `windows-sys`.
+- Updated `nix` dependency to 0.25.
+- Replaced `winapi` dependency with `windows-sys`.
 
 ## [0.15.0] - 2022-05-22
 
@@ -85,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Updated tokio dependency to 1.0.
+- Updated tokio dependency to 1.0.
 
 ## [0.11.0] - 2020-10-30
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -439,7 +439,7 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 }
             };
 
-            let mut cmd = AsyncCommand::new(&binary);
+            let mut cmd = AsyncCommand::new(binary);
             cmd.args(&self.args);
 
             if managed_by_rustwide {

--- a/src/crates/git.rs
+++ b/src/crates/git.rs
@@ -23,7 +23,7 @@ impl GitRepo {
 
         match res {
             Ok(out) => {
-                if let Some(shaline) = out.stdout_lines().get(0) {
+                if let Some(shaline) = out.stdout_lines().first() {
                     if !shaline.is_empty() {
                         return Some(shaline.to_string());
                     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -526,7 +526,7 @@ pub(crate) fn list_installed_toolchains(rustup_home: &Path) -> Result<Vec<Toolch
     let update_hashes = rustup_home.join("update-hashes");
 
     let mut result = Vec::new();
-    for entry in std::fs::read_dir(&rustup_home.join("toolchains"))? {
+    for entry in std::fs::read_dir(rustup_home.join("toolchains"))? {
         let entry = entry?;
         let name = entry
             .file_name()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,6 +30,7 @@ pub(crate) fn file_lock<T>(
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(path)?;
 
     let mut message_displayed = false;
@@ -108,26 +109,6 @@ fn improve_remove_error(error: std::io::Error, path: &Path) -> std::io::Error {
     )
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn custom_remove_error() {
-        let path = "test/path".as_ref();
-
-        let expected = "failed to remove 'test/path' : Kind(PermissionDenied)";
-        let tested = format!(
-            "{}",
-            improve_remove_error(
-                std::io::Error::from(std::io::ErrorKind::PermissionDenied),
-                path
-            )
-        );
-        assert_eq!(expected, tested);
-    }
-}
-
 pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     let mut p = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
@@ -161,6 +142,26 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     }
 
     p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_remove_error() {
+        let path = "test/path".as_ref();
+
+        let expected = "failed to remove 'test/path' : Kind(PermissionDenied)";
+        let tested = format!(
+            "{}",
+            improve_remove_error(
+                std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+                path
+            )
+        );
+        assert_eq!(expected, tested);
+    }
 }
 
 #[cfg(test)]

--- a/tests/buildtest/inside_docker.rs
+++ b/tests/buildtest/inside_docker.rs
@@ -36,7 +36,7 @@ fn execute(test: &str) -> Result<(), Error> {
     let target_prefix = Path::new(TARGET_PREFIX);
     let container_exe = target_prefix.join(
         current_exe
-            .strip_prefix(&target_parent_dir)
+            .strip_prefix(target_parent_dir)
             .with_context(|_| "could not determine cargo target dir")?,
     );
     let src_mount = os_string!(&current_dir, ":", &container_prefix);


### PR DESCRIPTION
In https://github.com/rust-lang/docs.rs/issues/2441 we had an issue where a single log line was in the 10s of MB ( [see this zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/increase.20max.20build.20log.20size) ). 

So now we want to truncate log-lines that are too wide, so we can keep the rest of the log-lines and still respect the general `max_size`. 