### PR TITLE
clear cargo global cache file when clearing caches 

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4,6 +4,7 @@ use crate::inside_docker::CurrentContainer;
 use crate::Toolchain;
 use failure::{Error, ResultExt};
 use log::info;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -234,6 +235,11 @@ impl Workspace {
             if path.exists() {
                 crate::utils::remove_dir_all(path)?;
             }
+        }
+
+        let global_cache = self.cargo_home().join(".global-cache");
+        if global_cache.exists() {
+            fs::remove_file(global_cache)?;
         }
 
         Ok(())


### PR DESCRIPTION
in other PRs (like #84) `integration::purge_caches::test_purge_caches` started failing with: 
```
 === start directory differences ===
file .workspaces/purge-caches/cargo-home/.global-cache changed its size
=== end directory differences ===
thread 'integration::purge_caches::test_purge_caches' panicked at tests/integration/purge_caches.rs:127:13:
the contents of the directory changed
```

My assumption is that when deleting other cargo caches we should also delete the (new-ish) `.global-cache` sqlite cache db. 