### PR TITLE
Extend CommandError::ExecutionFailed to optionally include stderr 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.0] - 2024-10-13
+
+- **BREAKING**  Extend `CommandError::ExecutionFailed` and `PrepareError` to optionally include stderr
+
 ## [0.17.0] - 2024-06-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwide"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2018"
 build = "build.rs"
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -71,8 +71,13 @@ pub enum CommandError {
     Timeout(u64),
 
     /// The command failed to execute.
-    #[error("command failed: {0}")]
-    ExecutionFailed(ExitStatus),
+    #[error("command failed: {status}\n\n{stderr}")]
+    ExecutionFailed {
+        /// the exit status we got from the command
+        status: ExitStatus,
+        /// the stderr output, if it was captured via `.run_capture()`
+        stderr: String,
+    },
 
     /// Killing the underlying process after the timeout failed.
     #[error("{0}")]
@@ -496,7 +501,10 @@ impl<'w, 'pl> Command<'w, 'pl> {
             if out.status.success() {
                 Ok(out.into())
             } else {
-                Err(CommandError::ExecutionFailed(out.status))
+                Err(CommandError::ExecutionFailed {
+                    status: out.status,
+                    stderr: out.stderr.join("\n"),
+                })
             }
         }
     }

--- a/src/cmd/sandbox.rs
+++ b/src/cmd/sandbox.rs
@@ -393,7 +393,7 @@ impl Container<'_> {
         // Return a different error if the container was killed due to an OOM
         if details.state.oom_killed {
             Err(match res {
-                Ok(_) | Err(CommandError::ExecutionFailed(_)) => CommandError::SandboxOOM,
+                Ok(_) | Err(CommandError::ExecutionFailed { .. }) => CommandError::SandboxOOM,
                 Err(err) => err,
             })
         } else {

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -188,22 +188,30 @@ test_prepare_error!(
     InvalidCargoTomlSyntax
 );
 
-test_prepare_error!(test_yanked_deps, "yanked-deps", YankedDependencies);
+test_prepare_error_stderr!(
+    test_yanked_deps,
+    "yanked-deps",
+    YankedDependencies,
+    r#"failed to select a version for the requirement `ring = "^0.2"`"#
+);
 
-test_prepare_error!(
+test_prepare_error_stderr!(
     test_missing_deps_git,
     "missing-deps-git",
-    MissingDependencies
+    MissingDependencies,
+    "failed to get `not-a-git-repo` as a dependency of package `missing-deps v0.1.0"
 );
 
-test_prepare_error!(
+test_prepare_error_stderr!(
     test_missing_deps_git_locked,
     "missing-deps-git-locked",
-    MissingDependencies
+    MissingDependencies,
+    "failed to get `not-a-git-repo` as a dependency of package `missing-deps-git-locked v0.1.0"
 );
 
-test_prepare_error!(
+test_prepare_error_stderr!(
     test_missing_deps_registry,
     "missing-deps-registry",
-    MissingDependencies
+    MissingDependencies,
+    "error: no matching package named `macro` found"
 );

--- a/tests/buildtest/runner.rs
+++ b/tests/buildtest/runner.rs
@@ -84,3 +84,25 @@ macro_rules! test_prepare_error {
         }
     };
 }
+
+macro_rules! test_prepare_error_stderr {
+    ($name:ident, $krate:expr, $expected:ident, $expected_output:expr) => {
+        #[test]
+        fn $name() {
+            runner::run($krate, |run| {
+                let res = run.run(
+                    rustwide::cmd::SandboxBuilder::new().enable_networking(false),
+                    |_| Ok(()),
+                );
+                if let Some(rustwide::PrepareError::$expected(output)) =
+                    res.err().and_then(|err| err.downcast().ok())
+                {
+                    assert!(output.contains($expected_output), "output: {:?}", output);
+                } else {
+                    panic!("didn't get the error {}", stringify!($expected));
+                }
+                Ok(())
+            });
+        }
+    };
+}


### PR DESCRIPTION
since https://github.com/rust-lang/docs.rs/pull/2467 we are now also seeing pre-build errors in docs.rs. 

Some of the errors need more details for crate authors to work with them, example issues: 
- https://github.com/rust-lang/docs.rs/issues/2624
- https://github.com/rust-lang/docs.rs/issues/2556
- https://github.com/rust-lang/docs.rs/issues/2424
- https://github.com/rust-lang/docs.rs/issues/797

( there are more, but these examples should suffice )

With this change we now extend `CommandError::ExecutionFailed` and the necessary `PrepareError` variants with the captured stderr output, which should give crate authors all the information they need. 