### PR TITLE
Make CARGO_HOME optionally writable

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -211,6 +211,7 @@ pub struct Command<'w, 'pl> {
     no_output_timeout: Option<Duration>,
     log_command: bool,
     log_output: bool,
+    cargo_home_mount_kind: MountKind,
 }
 
 impl<'w, 'pl> Command<'w, 'pl> {
@@ -261,7 +262,14 @@ impl<'w, 'pl> Command<'w, 'pl> {
             no_output_timeout,
             log_output: true,
             log_command: true,
+            cargo_home_mount_kind: MountKind::ReadOnly,
         }
+    }
+
+    /// Mount the cargo home directory as read-write in the sandbox.
+    pub fn rw_cargo_home(mut self) -> Self {
+        self.cargo_home_mount_kind = MountKind::ReadWrite;
+        self
     }
 
     /// Add command-line arguments to the command. This method can be called multiple times to add
@@ -413,7 +421,7 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 .mount(
                     &workspace.cargo_home(),
                     &container_dirs::CARGO_HOME,
-                    MountKind::ReadOnly,
+                    self.cargo_home_mount_kind,
                 )
                 .mount(
                     &workspace.rustup_home(),


### PR DESCRIPTION
We're running into issues with rustwide in [qrates](https://github.com/rust-corpus/qrates/) when incremental compilation is enabled:

```
--snip--
14:08:57 [INFO] [stdout] 948fb9cd0c36f8264ca53a8d474817f66d2eb5db6ca5eee8a9c271c2887d41c4
14:08:57 [INFO] running `Command { std: "docker" "start" "-a" "948fb9cd0c36f8264ca53a8d474817f66d2eb5db6ca5eee8a9c271c2887d41c4", kill_on_drop: false }`
14:08:57 [INFO] [stderr]     Checking powerfmt v0.2.0
14:08:57 [INFO] [stderr]     Checking num-conv v0.1.0
14:08:57 [INFO] [stderr]     Checking time-core v0.1.2
14:08:57 [INFO] [stderr] error: could not create incremental compilation crate directory `incremental/powerfmt-33plc6te6e1kj`: Read-only file system (os error 30)
14:08:57 [INFO] [stderr]
14:08:57 [INFO] [stderr] error: could not create incremental compilation crate directory `incremental/time_core-0itg8lzr2ib0v`: Read-only file system (os error 30)
14:08:57 [INFO] [stderr]
14:08:57 [INFO] [stderr] error: could not create incremental compilation crate directory `incremental/num_conv-2hmvxbsyjvjzr`: Read-only file system (os error 30)
14:08:57 [INFO] [stderr]
14:08:57 [INFO] [stderr] error: could not compile `time-core` (lib) due to 1 previous error
14:08:57 [INFO] [stderr] warning: build failed, waiting for other jobs to finish...
14:08:57 [INFO] [stderr] error: could not compile `powerfmt` (lib) due to 1 previous error
14:08:58 [INFO] [stderr] error: could not compile `num-conv` (lib) due to 1 previous error
--snip--
```

This PR adds an option to `Command` to allow mounting the `$CARGO_HOME` directory as read/write, which resolves our issue.

I am unsure if this is _the_ way to solve the issue, so I'm opening this PR in draft state. I would be happy as well if there was a way to set the incremental directory to something ephemeral inside the vfs and keeping `$CARGO_HOME` read-only. Our project is only interested in some side-effects of incremental compilation in rustc (computing HIR hashes), not the incremental nature itself.

Thanks!