### PR TITLE
freeze used rustup version to 1.27.1, don't self-update rustup 

### DIFF
--- a/examples/docs-builder.rs
+++ b/examples/docs-builder.rs
@@ -1,3 +1,4 @@
+use rustwide::cmd::SandboxImage;
 use rustwide::{cmd::SandboxBuilder, Crate, Toolchain, WorkspaceBuilder};
 use std::error::Error;
 use std::path::Path;
@@ -7,7 +8,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new workspace in .workspaces/docs-builder
     let workspace =
-        WorkspaceBuilder::new(Path::new(".workspaces/docs-builder"), "rustwide-examples").init()?;
+        WorkspaceBuilder::new(Path::new(".workspaces/docs-builder"), "rustwide-examples")
+            .sandbox_image(SandboxImage::remote(
+                "ghcr.io/rust-lang/crates-build-env/linux-micro",
+            )?)
+            .init()?;
 
     // Run the builds on stable
     let toolchain = Toolchain::dist("stable");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -49,6 +49,7 @@ impl DistToolchain {
                 self.name(),
                 "--profile",
                 workspace.rustup_profile(),
+                "--no-self-update",
             ])
             .run()
             .with_context(|| format!("unable to install toolchain {} via rustup", self.name()))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,6 +42,9 @@ pub(crate) fn file_lock<T>(
     }
 
     let res = std::panic::catch_unwind(f);
+    #[allow(unstable_name_collisions)]
+    // the method is coming from the `fs2` crate
+    // https://github.com/danburkert/fs2-rs/issues/50
     let _ = file.unlock();
 
     match res {


### PR DESCRIPTION
temporary workaround for #94 
see also https://github.com/rust-lang/rustup/issues/4224 

I want to downgrade first to make docs.rs builds work again. 

Then we can take time to figure out the best solution. 