### PR TITLE
Don't canoncalize binary names

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -437,14 +437,15 @@ impl<'w, 'pl> Command<'w, 'pl> {
                 // global paths should never be normalized
                 Binary::Global(path) => (path, false),
                 Binary::ManagedByRustwide(path) => {
-                    let binary = self
-                        .workspace
-                        .expect("calling rustwide bins without a workspace is not supported")
-                        .cargo_home()
-                        .join("bin")
-                        .join(exe_suffix(path.as_os_str()));
                     // `cargo_home()` might a relative path
-                    (crate::utils::normalize_path(&binary), true)
+                    let cargo_home = crate::utils::normalize_path(
+                        &self
+                            .workspace
+                            .expect("calling rustwide bins without a workspace is not supported")
+                            .cargo_home(),
+                    );
+                    let binary = cargo_home.join("bin").join(exe_suffix(path.as_os_str()));
+                    (binary, true)
                 }
             };
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -49,7 +49,6 @@ impl DistToolchain {
                 self.name(),
                 "--profile",
                 workspace.rustup_profile(),
-                "--no-self-update",
             ])
             .run()
             .with_context(|| format!("unable to install toolchain {} via rustup", self.name()))?;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -38,11 +38,11 @@ trait Tool: Send + Sync {
     fn update(&self, workspace: &Workspace, fast_install: bool) -> anyhow::Result<()>;
 
     fn binary_path(&self, workspace: &Workspace) -> PathBuf {
-        crate::utils::normalize_path(&workspace.cargo_home().join("bin").join(format!(
-            "{}{}",
-            self.name(),
-            EXE_SUFFIX
-        )))
+        // `cargo_home()` might a relative path
+        let cargo_home = crate::utils::normalize_path(&workspace.cargo_home());
+        cargo_home
+            .join("bin")
+            .join(format!("{}{}", self.name(), EXE_SUFFIX))
     }
 }
 

--- a/src/tools/rustup.rs
+++ b/src/tools/rustup.rs
@@ -8,10 +8,7 @@ use std::fs::{self, File};
 use std::io;
 use tempfile::tempdir;
 
-// we're using an old version of rustup, since rustup 1.28 is broken for rustwide for now.
-// We'll try to either fix rustup, or adapt rustwide to fix this, until then, we'll use this version.
-// see https://github.com/rust-lang/rustup/issues/4224
-static RUSTUP_VERSION: &str = "1.27.1";
+static RUSTUP_BASE_URL: &str = "https://static.rust-lang.org/rustup/dist";
 
 pub(crate) struct Rustup;
 
@@ -40,10 +37,10 @@ impl Tool for Rustup {
         fs::create_dir_all(workspace.rustup_home())?;
 
         let url = format!(
-            "https://static.rust-lang.org/rustup/archive/{version}/{target}/rustup-init{exe_suffix}",
-            version = RUSTUP_VERSION,
-            target = crate::HOST_TARGET,
-            exe_suffix = EXE_SUFFIX
+            "{}/{}/rustup-init{}",
+            RUSTUP_BASE_URL,
+            crate::HOST_TARGET,
+            EXE_SUFFIX
         );
         let mut resp = workspace
             .http_client()
@@ -78,7 +75,11 @@ impl Tool for Rustup {
 
     fn update(&self, workspace: &Workspace, _fast_install: bool) -> anyhow::Result<()> {
         Command::new(workspace, &RUSTUP)
-            .args(&["update", MAIN_TOOLCHAIN_NAME, "--no-self-update"])
+            .args(&["self", "update"])
+            .run()
+            .context("failed to update rustup")?;
+        Command::new(workspace, &RUSTUP)
+            .args(&["update", MAIN_TOOLCHAIN_NAME])
             .run()
             .with_context(|| format!("failed to update main toolchain {}", MAIN_TOOLCHAIN_NAME))?;
         Ok(())


### PR DESCRIPTION
This avoids rustup shims being resolved to their real path (i.e. `rustup[.exe]`) instead of their shim name (e.g. `cargo[.exe]`).

Hopefully fixes #94