### PR TITLE
detect more failure cases

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -214,7 +214,7 @@ pub struct Command<'w, 'pl> {
     source_dir_mount_kind: MountKind,
 }
 
-impl<'w, 'pl> Command<'w, 'pl> {
+impl<'w> Command<'w, '_> {
     /// Create a new, unsandboxed command.
     pub fn new<R: Runnable>(workspace: &'w Workspace, binary: R) -> Self {
         binary.prepare_command(Self::new_inner(binary.name(), Some(workspace), None))
@@ -331,10 +331,10 @@ impl<'w, 'pl> Command<'w, 'pl> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn process_lines<'pl2>(
+    pub fn process_lines<'pl>(
         self,
-        f: &'pl2 mut dyn FnMut(&str, &mut ProcessLinesActions),
-    ) -> Command<'w, 'pl2> {
+        f: &'pl mut dyn FnMut(&str, &mut ProcessLinesActions),
+    ) -> Command<'w, 'pl> {
         Command {
             process_lines: Some(f),
             ..self

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -331,9 +331,14 @@ impl<'w, 'pl> Command<'w, 'pl> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn process_lines(mut self, f: &'pl mut dyn FnMut(&str, &mut ProcessLinesActions)) -> Self {
-        self.process_lines = Some(f);
-        self
+    pub fn process_lines<'pl2>(
+        self,
+        f: &'pl2 mut dyn FnMut(&str, &mut ProcessLinesActions),
+    ) -> Command<'w, 'pl2> {
+        Command {
+            process_lines: Some(f),
+            ..self
+        }
     }
 
     /// Enable or disable logging all the output lines to the [`log` crate][log]. By default

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -153,6 +153,7 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             yanked_deps = true;
         } else if line.contains("failed to load source for dependency")
             || line.contains("no matching package named")
+            || line.contains("no matching package found")
         {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -154,6 +154,7 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
         } else if line.contains("failed to load source for dependency")
             || line.contains("no matching package named")
             || line.contains("no matching package found")
+            || line.contains("no matching package for override ")
         {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -154,7 +154,9 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             || line.contains("no matching package named")
         {
             missing_deps = true;
-        } else if line.contains("failed to parse manifest at") {
+        } else if line.contains("failed to parse manifest at")
+            || line.contains("error: invalid table header")
+        {
             broken_deps = true;
         }
     };

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -155,6 +155,8 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             || line.contains("no matching package named")
             || line.contains("no matching package found")
             || line.contains("no matching package for override ")
+            || (line.contains("The patch location ")
+                && line.contains(" does not appear to contain any packages matching the name "))
         {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -158,6 +158,7 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")
             || line.contains("error: invalid table header")
+            || line.contains("error: invalid type: ")
             || line.contains("error: cyclic feature dependency: feature ")
             || line.contains("error: cyclic package dependency: package ")
         {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -158,6 +158,7 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")
             || line.contains("error: invalid table header")
+            || line.contains("error: cyclic feature dependency: feature ")
         {
             broken_deps = true;
         } else if line.contains("error: failed to parse lock file at") {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -164,7 +164,11 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             || line.contains("error: cyclic package dependency: package ")
         {
             broken_deps = true;
-        } else if line.contains("error: failed to parse lock file at") {
+        } else if line.contains("error: failed to parse lock file at")
+            || line.contains(
+                "error: Attempting to resolve a dependency with more than one crate with links=",
+            )
+        {
             broken_lockfile = true;
         }
     };

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -164,6 +164,10 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             || line.contains("error: invalid type: ")
             || line.contains("error: cyclic feature dependency: feature ")
             || line.contains("error: cyclic package dependency: package ")
+            || (line.contains("error: package collision in the lockfile: packages ")
+                && line.contains(
+                    " are different, but only one can be written to lockfile unambiguously",
+                ))
         {
             broken_deps = true;
         } else if line.contains("error: failed to parse lock file at")

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -159,6 +159,7 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
         } else if line.contains("failed to parse manifest at")
             || line.contains("error: invalid table header")
             || line.contains("error: cyclic feature dependency: feature ")
+            || line.contains("error: cyclic package dependency: package ")
         {
             broken_deps = true;
         } else if line.contains("error: failed to parse lock file at") {

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -289,7 +289,7 @@ test_prepare_error_stderr!(
     "error: no matching package found"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_cyclic_feature,
     "invalid-cargotoml-cyclic-feature",
     BrokenDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -282,7 +282,7 @@ test_prepare_error_stderr!(
     "error: failed to parse lock file at"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_missing_deps_typo,
     "missing-deps-typo",
     MissingDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -268,7 +268,7 @@ test_prepare_error_stderr!(
     "failed to parse the version requirement `0.11\t` for dependency `parking_lot`"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_syntax_deps,
     "invalid-cargotoml-syntax-deps",
     BrokenDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -323,7 +323,7 @@ test_prepare_error_stderr!(
     "error: failed to select a version for the requirement `empty-library = \"=0.5.0\"`"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_content_type_in_deps,
     "invalid-cargotoml-content-type-in-deps",
     BrokenDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -261,7 +261,7 @@ test_prepare_error_stderr!(
     "error: no matching package named `macro` found"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_content_deps,
     "invalid-cargotoml-content-deps",
     BrokenDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -296,7 +296,7 @@ test_prepare_error_stderr!(
     "error: cyclic feature dependency: feature"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_cyclic_package,
     "invalid-cargotoml-cyclic-package",
     BrokenDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -309,7 +309,7 @@ test_prepare_error!(
     InvalidCargoTomlSyntax
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_missing_override,
     "invalid-cargotoml-missing-override",
     MissingDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -275,7 +275,7 @@ test_prepare_error_stderr!(
     "error: invalid table header"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_lockfile_syntax,
     "invalid-lockfile-syntax",
     InvalidCargoLock,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -344,7 +344,7 @@ test_prepare_uncategorized_err!(
     "error: package collision in the lockfile: packages lockfile-collision v0.1.0 "
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_missing_patch,
     "invalid-cargotoml-missing-patch",
     MissingDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -337,7 +337,7 @@ test_prepare_error_stderr!(
     "error: Attempting to resolve a dependency with more than one crate with links=ring-asm"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_lockfile_collision,
     "lockfile-collision",
     BrokenDependencies,

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -316,10 +316,10 @@ test_prepare_uncategorized_err!(
     "no matching package for override `https://github.com/rust-lang/crates.io-index#build-rs@0.1.2` found"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_missing_deps_registry_version,
     "missing-deps-registry-version",
-    MissingDependencies,
+    YankedDependencies,
     "error: failed to select a version for the requirement `empty-library = \"=0.5.0\"`"
 );
 

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -330,7 +330,7 @@ test_prepare_error_stderr!(
     "error: invalid type: map, expected a string"
 );
 
-test_prepare_uncategorized_err!(
+test_prepare_error_stderr!(
     test_invalid_cargotoml_conflicting_links,
     "invalid-cargotoml-conflicting-links",
     InvalidCargoLock,

--- a/tests/buildtest/runner.rs
+++ b/tests/buildtest/runner.rs
@@ -96,8 +96,6 @@ macro_rules! test_prepare_error {
     };
 }
 
-pub(crate) use test_prepare_error;
-
 macro_rules! test_prepare_error_stderr {
     ($name:ident, $krate:expr, $expected:ident, $expected_output:expr) => {
         #[test]
@@ -128,11 +126,5 @@ macro_rules! test_prepare_error_stderr {
                 Ok(())
             });
         }
-    };
-}
-
-macro_rules! test_prepare_uncategorized_err {
-    ($name:ident, $krate:expr, $expected:ident $(,$expected_output:expr)?) => {
-        $crate::buildtest::runner::test_prepare_error!($name, $krate, Uncategorized);
     };
 }


### PR DESCRIPTION
I think this is best reviewed commit-by-commit.

The first commit adds a sanity check for the buildtest crates and fixes an existing deviation.

The second commits adds a bunch of buildtest tests and crates that weren't handled before this PR.
The added tests/crates have been found by looking through the crater runs classifier as `Error` in the crater experiment [beta-1.86-1](https://crater-reports.s3.amazonaws.com/beta-1.86-1/index.html).

The remaining commits work through the added tests to properly classify them.

With these crates classified crater should sort them into the `Broken` category rather than the ~~`Error`~~ `PrepareFail` category. (For the existing `PrepareError` variants immediately when the dependency is updated, for the new variants they would need to be added to be recognized in [detect_broken](https://github.com/rust-lang/crater/blob/53fc2eaed3e467a27cf135e4603ed8820efb77ec/src/runner/test.rs#L68))
