### PR TITLE
 move validate_manifest to after remove_override_files & tweak_toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.19.4] - 2025-06-17
+
+### Fixed
+  
+- "move manifest validation later in the preparation to harden against possible cargo changes
+
+
 ## [0.19.3] - 2025-06-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwide"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2018"
 build = "build.rs"
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -35,9 +35,9 @@ impl<'a> Prepare<'a> {
 
     pub(crate) fn prepare(&mut self) -> anyhow::Result<()> {
         self.krate.copy_source_to(self.workspace, self.source_dir)?;
-        self.validate_manifest()?;
         self.remove_override_files()?;
         self.tweak_toml()?;
+        self.validate_manifest()?;
         self.capture_lockfile()?;
         self.fetch_deps()?;
 


### PR DESCRIPTION
 to safeguard against potential future security issues