### PR TITLE
rename default branch to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - "**"
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Install Rust stable
         run: |
@@ -45,7 +45,7 @@ jobs:
             test_flags: --skip buildtest --skip integration --skip run_binary_with_same_name_as_file
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Install Rust stable
         run: |


### PR DESCRIPTION
there is [no branch protection configured here](https://github.com/rust-lang/team/blob/dc435ef02b8b0eb8990926275b7f5f8b5d269cec/repos/rust-lang/rustwide.toml), so this is the only thing we need to do, apart from your manual change, right? 