### PR TITLE
adjustments due to changes in error messages as of cargo for rust 1.90

### DIFF
--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -161,6 +161,7 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")
             || line.contains("error: invalid table header")
+            || (line.contains("error: unexpected ") && line.contains(", expected "))
             || line.contains("error: invalid type: ")
             || line.contains("error: cyclic feature dependency: feature ")
             || line.contains("error: cyclic package dependency: package ")

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -272,7 +272,7 @@ test_prepare_error_stderr!(
     test_invalid_cargotoml_syntax_deps,
     "invalid-cargotoml-syntax-deps",
     BrokenDependencies,
-    "error: invalid table header"
+    "error: unexpected "
 );
 
 test_prepare_error_stderr!(


### PR DESCRIPTION
- also match new error message
- adjusted the tests expected output

---

Timeline

- 2025-06-06 toml-rs/toml#922 is merged changing the toml parser and in turn the error message
  - ‎see the diff of [‎crates/toml/tests/snapshots/invalid/key/after-array.stderr](https://github.com/toml-rs/toml/pull/922/files#diff-f70da65aa0137cf70b33d1076724d1bdc77fe63b3c88af59e501d325fec92ee4)
- 2025-07-08 release of toml_edit on crates.io 2.30.0
- 2025-07-09 rust-lang/cargo#15736 updates toml_edit dependency to to 2.30.0
- 2025-07-11 rust-lang/rust#143809 pulls an updated rust-lang/cargo into 1.90 nightly rust-lang/rust
- 2025-08-01 nightly branched to beta
- 2025-08-23 last time CI ran on my PR #404: succeeds (presumably against stable 1.89, CI logs expired)
- 2025-09-18 stable 1.90 is released
- 2025-12-02 my PR is merged into master and branch CI runs: failing against stable 1.91.1