### PR TITLE
arbitrary package upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,26 +28,26 @@ serde_json = "1.0"
 scopeguard = "1.0.0"
 lazy_static = "1.0.0"
 tempfile = "3.0.0"
-attohttpc = "0.28.0"
+attohttpc = "0.30.1"
 flate2 = "1"
 tar = "0.4.0"
 percent-encoding = "2.1.0"
 walkdir = "2.2"
-toml = "0.8.12"
+toml = "0.9.10"
 fs2 = "0.4.3"
-remove_dir_all = "0.8.2"
+remove_dir_all = "1.0.0"
 base64 = "0.22.0"
-getrandom = { version = "0.2", features = ["std"] }
-thiserror = "1.0.20"
-git2 = "0.19.0"
+getrandom = { version = "0.3.4", features = ["std"] }
+thiserror = "2.0.17"
+git2 = "0.20.2"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29.0", features = ["signal", "user"]}
+nix = { version = "0.30.0", features = ["signal", "user"]}
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = {version = "0.52.0", features = ["Win32_Foundation", "Win32_System_Threading"]}
 
 [dev-dependencies]
 env_logger = "0.11.3"
-rand = "0.8.5"
+rand = "0.9.2"
 tiny_http = "0.12.0"

--- a/src/inside_docker.rs
+++ b/src/inside_docker.rs
@@ -1,7 +1,6 @@
 use crate::cmd::Command;
 use crate::workspace::Workspace;
 use base64::{engine::general_purpose::STANDARD as b64, Engine};
-use getrandom::getrandom;
 use log::info;
 
 static PROBE_FILENAME: &str = "rustwide-probe";
@@ -51,7 +50,7 @@ pub(crate) fn probe_container_id(workspace: &Workspace) -> anyhow::Result<Option
     let probe_path = std::env::temp_dir().join(PROBE_FILENAME);
     let probe_path_str = probe_path.to_str().unwrap();
     let mut probe_content = [0u8; 64];
-    getrandom(&mut probe_content)?;
+    getrandom::fill(&mut probe_content)?;
     let probe_content = b64.encode(&probe_content[..]);
     std::fs::write(&probe_path, probe_content.as_bytes())?;
 

--- a/tests/buildtest/runner.rs
+++ b/tests/buildtest/runner.rs
@@ -1,4 +1,4 @@
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distr::Alphanumeric, Rng};
 use rustwide::{cmd::SandboxBuilder, Build, BuildBuilder, Crate, Toolchain, Workspace};
 use std::path::Path;
 
@@ -41,7 +41,7 @@ impl Runner {
         f: impl FnOnce(BuildBuilder) -> anyhow::Result<T>,
     ) -> anyhow::Result<T> {
         // Use a random string at the end to avoid conflicts if multiple tests use the same source crate.
-        let suffix: String = rand::thread_rng()
+        let suffix: String = rand::rng()
             .sample_iter(&Alphanumeric)
             .take(10)
             .map(char::from)


### PR DESCRIPTION
I did not upgrade `windows-sys` (0.61.2), there were errors in CI, and I don't know enough about the C interface here to be fix that quickly. 

#### breaking changelogs: 
- https://github.com/sbstp/attohttpc/releases/tag/v0.29.0
- https://github.com/sbstp/attohttpc/releases/tag/v0.30.0
- https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#090---2025-07-08
- https://github.com/XAMPPRocky/remove_dir_all/compare/v0.8.0...1.0.0
- https://github.com/rust-random/getrandom/blob/master/CHANGELOG.md#030---2025-01-25
- https://github.com/dtolnay/thiserror/releases/tag/2.0.0
- https://github.com/rust-lang/git2-rs/blob/master/CHANGELOG.md#0200---2025-01-04
- https://github.com/rust-random/rand/blob/master/CHANGELOG.md#090---2025-01-27