### PR TITLE
remove obsolete explicit doc_rs flag in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,12 @@
-use std::error::Error;
+use std::{env, error::Error, fs};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // This prevents Cargo from rebuilding everything each time a non source code file changes.
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo::rustc-check-cfg=cfg(docs_rs)");
 
-    let target = std::env::var("TARGET")?;
-
-    let output = std::env::var("OUT_DIR")?;
-    ::std::fs::write(format!("{output}/target"), target.as_bytes())?;
-
-    println!("cargo:rerun-if-env-changed=DOCS_RS");
-    if std::env::var_os("DOCS_RS").as_deref() == Some(std::ffi::OsStr::new("1")) {
-        println!("cargo:rustc-cfg=docs_rs");
-    }
+    let target = env::var("TARGET")?;
+    let output = env::var("OUT_DIR")?;
+    fs::write(format!("{output}/target"), target.as_bytes())?;
 
     Ok(())
 }


### PR DESCRIPTION
see 
- https://docs.rs/about/builds#detecting-docsrs
- https://github.com/rust-lang/docs.rs/issues/2389
- https://github.com/rust-lang/docs.rs/pull/2390


https://github.com/bevyengine/bevy/issues/14132