### PR TITLE
Make `Crate::copy_source_to` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* make `Crate::copy_source_to` public.
+
 ## [0.22.0] - 2026-04-01
 
 * **BREAKING**: replace lazy_static with LazyLock, add MSRV to what is in the code

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -74,7 +74,10 @@ impl Crate {
         }
     }
 
-    pub(crate) fn copy_source_to(&self, workspace: &Workspace, dest: &Path) -> anyhow::Result<()> {
+    /// copy the source of this crate to the specified destination path.
+    ///
+    /// Will delete the target directory if it already exists.
+    pub fn copy_source_to(&self, workspace: &Workspace, dest: &Path) -> anyhow::Result<()> {
         if dest.exists() {
             info!(
                 "crate source directory {} already exists, cleaning it up",


### PR DESCRIPTION
needed for https://github.com/rust-lang/docs.rs/issues/3136, but IMO generally useful