### PR TITLE
support new cargo error in rust 1.95

### DIFF
--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -157,6 +157,8 @@ fn run_command(cmd: Command) -> anyhow::Result<()> {
             || line.contains("no matching package for override ")
             || (line.contains("The patch location ")
                 && line.contains(" does not appear to contain any packages matching the name "))
+            || (line.contains("patch location ")
+                && line.contains(" does not contain packages matching "))
         {
             missing_deps = true;
         } else if line.contains("failed to parse manifest at")

--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -431,5 +431,5 @@ test_prepare_error_stderr!(
     test_invalid_cargotoml_missing_patch,
     "invalid-cargotoml-missing-patch",
     MissingDependencies,
-    "The patch location `https://github.com/rust-lang/rustwide.git?rev=07784be00b68cfd6bf80006c8d8669a7d6374ec2` does not appear to contain any packages matching the name `build-rs`"
+    "patch location `https://github.com/rust-lang/rustwide.git?rev=07784be00b68cfd6bf80006c8d8669a7d6374ec2` does not contain packages matching `build-rs`"
 );


### PR DESCRIPTION
see failure in [this other CI run](https://github.com/rust-lang/rustwide/actions/runs/24624191683/job/72000147371). 

```
[96](https://github.com/rust-lang/rustwide/actions/runs/24624191683/job/72000147371#step:6:197)
 rustwide::cmd] [stderr]     Updating git repository `[https://github.com/rust-lang/rustwide.git`](https://github.com/rust-lang/rustwide.git%60)
 rustwide::cmd] [stderr] error: invalid character `!` in package name: `!`, the first character must be a Unicode XID start character (most letters or `_`)
 rustwide::cmd] [stderr]  --> ../../../cargo-home/git/checkouts/rustwide-42b79ae0da483ace/07784be/tests/buildtest/crates/invalid-cargotoml-content/Cargo.toml:2:8
 rustwide::cmd] [stderr]   |
 rustwide::cmd] [stderr] 2 | name = "!"
 rustwide::cmd] [stderr]   |        ^^^
 rustwide::cmd] [stderr] error: key with no value, expected `=`
 rustwide::cmd] [stderr]  --> ../../../cargo-home/git/checkouts/rustwide-42b79ae0da483ace/07784be/tests/buildtest/crates/invalid-cargotoml-syntax/Cargo.toml:1:9
 rustwide::cmd] [stderr]   |
 rustwide::cmd] [stderr] 1 | Invalid!
 rustwide::cmd] [stderr]   |         ^
 rustwide::cmd] [stderr] error: patch location `https://github.com/rust-lang/rustwide.git?rev=07784be00b68cfd6bf80006c8d8669a7d6374ec2` does not contain packages matching `build-rs`
 rustwide::cmd] [stderr] help: check `build-rs` patch definition for `[https://github.com/rust-lang/crates.io-index`](https://github.com/rust-lang/crates.io-index%60) in `/home/runner/work/rustwide/rustwide/.workspaces/integration/builds/invalid-cargotoml-missing-patch-FzLmTQjDou/source/Cargo.toml`

thread 'buildtest::test_invalid_cargotoml_missing_patch' (10055) panicked at tests/buildtest/mod.rs:430:1:
expected PrepareError::MissingDependencies error, got Uncategorized instead
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    buildtest::test_invalid_cargotoml_missing_patch
```


similar PR in https://github.com/rust-lang/rustwide/pull/106. 

