### PR TITLE
hide alternate registry support behind feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         os: [ubuntu-22.04, windows-latest]
         cargo_flags:
           - ""
+          - "--no-default-features"
           - "--all-features"
         include:
           # Integration tests are disabled on Windows as they take *way* too

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["alternate-registries"]
+
+alternate-registries = ["dep:git2"]
 unstable = []
 unstable-toolchain-ci = []
 
@@ -39,7 +42,7 @@ remove_dir_all = "1.0.0"
 base64 = "0.22.0"
 getrandom = { version = "0.4.1", features = ["std"] }
 thiserror = "2.0.17"
-git2 = "0.20.2"
+git2 = { version = "0.20.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30.0", features = ["signal", "user"]}

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -6,6 +6,7 @@ use crate::Workspace;
 use log::info;
 use std::path::Path;
 
+#[cfg(feature = "alternate-registries")]
 pub use registry::AlternativeRegistry;
 
 trait CrateTrait: std::fmt::Display {
@@ -25,6 +26,7 @@ pub struct Crate(CrateType);
 
 impl Crate {
     /// Load a crate from specified registry.
+    #[cfg(feature = "alternate-registries")]
     pub fn registry(registry: AlternativeRegistry, name: &str, version: &str) -> Self {
         Crate(CrateType::Registry(registry::RegistryCrate::new(
             registry::Registry::Alternative(registry),

--- a/src/crates/registry.rs
+++ b/src/crates/registry.rs
@@ -1,5 +1,6 @@
 use super::CrateTrait;
 use crate::Workspace;
+#[cfg(feature = "alternate-registries")]
 use anyhow::Context as _;
 use flate2::read::GzDecoder;
 use log::info;
@@ -11,11 +12,13 @@ use tar::Archive;
 static CRATES_ROOT: &str = "https://static.crates.io/crates";
 
 /// A type for alternative registry as described in rust-lang/rfcs#2141
+#[cfg(feature = "alternate-registries")]
 pub struct AlternativeRegistry {
     registry_index: String,
     key: Option<String>,
 }
 
+#[cfg(feature = "alternate-registries")]
 impl AlternativeRegistry {
     /// Registry for specified registry index
     pub fn new(registry_index: impl Into<String>) -> AlternativeRegistry {
@@ -41,6 +44,7 @@ impl AlternativeRegistry {
 
 pub(crate) enum Registry {
     CratesIo,
+    #[cfg(feature = "alternate-registries")]
     Alternative(AlternativeRegistry),
 }
 
@@ -48,6 +52,7 @@ impl Registry {
     fn cache_folder(&self) -> String {
         match self {
             Registry::CratesIo => "cratesio-sources".into(),
+            #[cfg(feature = "alternate-registries")]
             Registry::Alternative(alt) => format!("{}-sources", alt.index_folder()),
         }
     }
@@ -55,6 +60,7 @@ impl Registry {
     fn name(&self) -> String {
         match self {
             Registry::CratesIo => "crates.io".into(),
+            #[cfg(feature = "alternate-registries")]
             Registry::Alternative(alt) => alt.index().to_string(),
         }
     }
@@ -66,6 +72,7 @@ pub(super) struct RegistryCrate {
     version: String,
 }
 
+#[cfg(feature = "alternate-registries")]
 #[derive(serde::Deserialize)]
 struct IndexConfig {
     dl: String,
@@ -88,12 +95,14 @@ impl RegistryCrate {
             .join(format!("{}-{}.crate", self.name, self.version))
     }
 
+    #[allow(unused_variables)]
     fn fetch_url(&self, workspace: &Workspace) -> anyhow::Result<String> {
         match &self.registry {
             Registry::CratesIo => Ok(format!(
                 "{0}/{1}/{1}-{2}.crate",
                 CRATES_ROOT, self.name, self.version
             )),
+            #[cfg(feature = "alternate-registries")]
             Registry::Alternative(alt) => {
                 let index_path = workspace
                     .cache_dir()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,9 @@ mod utils;
 mod workspace;
 
 pub use crate::build::{Build, BuildBuilder, BuildDirectory};
-pub use crate::crates::{AlternativeRegistry, Crate};
+#[cfg(feature = "alternate-registries")]
+pub use crate::crates::AlternativeRegistry;
+pub use crate::crates::Crate;
 pub use crate::prepare::PrepareError;
 pub use crate::toolchain::Toolchain;
 pub use crate::workspace::{Workspace, WorkspaceBuilder};

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alternate-registries")]
 mod crates_alt;
 mod crates_git;
 mod purge_caches;


### PR DESCRIPTION
- docs.rs doesn't need it 
- it adds a couple dependencies (`git2` among others, ~40) 

It think this is the "clean" way that makes most sense. 

Alternative would be to only remove `remote_callbacks` (for git auth) via feature, and use migrate to `gix`. but then again, it's not used in docs.rs