### PR TITLE
remove some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ tar = "0.4.0"
 percent-encoding = "2.1.0"
 walkdir = "2.2"
 toml = "1.1.2"
-fs2 = "0.4.3"
 remove_dir_all = "1.0.0"
 base64 = "0.22.0"
 getrandom = { version = "0.4.1", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ unstable-toolchain-ci = []
 tracing = ["dep:tracing"]
 
 [dependencies]
-http = "1.1.0"
 anyhow = { version = "1.0.68", features = ["backtrace"]}
 futures-util = "0.3.5"
 log = "0.4.6"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
-use fs2::FileExt;
 use log::warn;
 use percent_encoding::{AsciiSet, CONTROLS};
-use std::fs::OpenOptions;
+use std::fs::{OpenOptions, TryLockError};
 use std::path::{Component, Path, PathBuf, Prefix, PrefixComponent};
 
 const ENCODE_SET: AsciiSet = CONTROLS
@@ -32,13 +31,13 @@ pub(crate) fn file_lock<T>(
         .truncate(true)
         .open(path)?;
 
-    let mut message_displayed = false;
-    while let Err(err) = file.try_lock_exclusive() {
-        if !message_displayed && err.kind() == fs2::lock_contended_error().kind() {
+    match file.try_lock() {
+        Ok(_) => {}
+        Err(TryLockError::WouldBlock) => {
             warn!("blocking on other processes finishing to {msg}");
-            message_displayed = true;
+            file.lock()?;
         }
-        file.lock_exclusive()?;
+        Err(err) => return Err(err.into()),
     }
 
     let res = std::panic::catch_unwind(f);

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3,6 +3,7 @@ use crate::build::BuildDirectory;
 use crate::cmd::{Command, SandboxImage};
 use crate::inside_docker::CurrentContainer;
 use anyhow::Context as _;
+use attohttpc::header;
 use log::info;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -153,7 +154,7 @@ impl WorkspaceBuilder {
             };
 
             let mut agent = attohttpc::Session::new();
-            agent.header(http::header::USER_AGENT, self.user_agent);
+            agent.header(header::USER_AGENT, self.user_agent);
 
             let mut ws = Workspace {
                 inner: Arc::new(WorkspaceInner {


### PR DESCRIPTION
- replace direct `http` with re-export from `attohttpc` 
- replace `fs2` with stdlib file-locking (added in `1.89`)