### PR TITLE
Update tests to fix CI 

### DIFF
--- a/tests/buildtest/mod.rs
+++ b/tests/buildtest/mod.rs
@@ -433,7 +433,7 @@ test_prepare_error_stderr!(
     test_missing_deps_typo,
     "missing-deps-typo",
     MissingDependencies,
-    "error: no matching package found"
+    "error: no matching package named"
 );
 
 test_prepare_error_stderr!(

--- a/tests/integration/crates_alt.rs
+++ b/tests/integration/crates_alt.rs
@@ -7,7 +7,7 @@ fn test_fetch() -> anyhow::Result<()> {
     let workspace = crate::utils::init_workspace()?;
 
     let alt = AlternativeRegistry::new(INDEX_URL);
-    let krate = Crate::registry(alt, "foo", "0.4.0");
+    let krate = Crate::registry(alt, "gcc", "0.3.38");
     krate.fetch(&workspace)?;
 
     Ok(())


### PR DESCRIPTION
- the error msg changed, updating the tests. we don't test old versions for now 
- the crate we test alternate registries with [was deleted](https://github.com/rust-lang/staging.crates.io-index/commit/a9a8b2e3fbce7faccc19b29fab75f8a24f39ea9b), so we just use an existing one. 


 